### PR TITLE
Fix sitemap URL

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.absmach.eu/sitemap.xml
+Sitemap: https://absmach.eu/sitemap.xml


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->

<!--

Fix robots.txt sitemap URL to point to the canonical non-www domain to avoid GSC 'couldn’t fetch' errors.