### PR TITLE
NOISSUE - SEO: add comparison pages, IIoT pillar page, and on-page optimisations

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -138,7 +138,9 @@ const year = new Date().getFullYear();
         </ul>
         <p class="footer-nav-heading" style="margin-top:20px;">Guides</p>
         <ul>
-          <li><a href="/iiot-platform-architecture">IIoT Architecture Guide</a></li>
+          <li>
+            <a href="/iiot-platform-architecture">IIoT Architecture Guide</a>
+          </li>
           <li><a href="/emqx-alternative">EMQX Alternative</a></li>
           <li><a href="/mosquitto-alternative">Mosquitto Alternative</a></li>
         </ul>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -136,6 +136,12 @@ const year = new Date().getFullYear();
           <li><a href="/services">Services</a></li>
           <li><a href="/projects">Projects</a></li>
         </ul>
+        <p class="footer-nav-heading" style="margin-top:20px;">Guides</p>
+        <ul>
+          <li><a href="/iiot-platform-architecture">IIoT Architecture Guide</a></li>
+          <li><a href="/emqx-alternative">EMQX Alternative</a></li>
+          <li><a href="/mosquitto-alternative">Mosquitto Alternative</a></li>
+        </ul>
       </div>
 
       <!-- Company -->

--- a/src/pages/emqx-alternative.astro
+++ b/src/pages/emqx-alternative.astro
@@ -110,9 +110,9 @@ const faqSchema = JSON.stringify({
             The open-source EMQX alternative with no enterprise tier.
           </h1>
           <p class="lede" style="margin-top:20px; max-width:52ch;">
-            EMQX is a mature MQTT broker. FluxMQ ships clustering, durable queues,
-            AMQP support, and 500K+ connections per node — all under Apache 2.0
-            with no features locked behind a commercial edition.
+            EMQX is a mature MQTT broker. FluxMQ ships clustering, durable
+            queues, AMQP support, and 500K+ connections per node — all under
+            Apache 2.0 with no features locked behind a commercial edition.
           </p>
           <div class="btn-row" style="margin-top:32px;">
             <a href="/products/fluxmq" class="btn btn-primary">
@@ -186,8 +186,8 @@ const faqSchema = JSON.stringify({
           <div class="alt-pro-card">
             <div class="alt-pro-title">Dashboard UI</div>
             <p class="alt-pro-desc">
-              EMQX ships a web dashboard for monitoring connections, topics,
-              and subscriptions.
+              EMQX ships a web dashboard for monitoring connections, topics, and
+              subscriptions.
             </p>
           </div>
         </div>
@@ -210,7 +210,9 @@ const faqSchema = JSON.stringify({
         </div>
         <div class="alt-limit-grid">
           <div class="alt-limit-item">
-            <div class="alt-limit-title">AMQP 0.9.1 & 1.0 on the same broker</div>
+            <div class="alt-limit-title">
+              AMQP 0.9.1 & 1.0 on the same broker
+            </div>
             <p class="alt-limit-desc">
               EMQX is an MQTT broker. FluxMQ natively speaks MQTT, AMQP 0.9.1,
               AMQP 1.0, CoAP, and HTTP-MQTT — all routing through the same Queue
@@ -218,15 +220,19 @@ const faqSchema = JSON.stringify({
             </p>
           </div>
           <div class="alt-limit-item">
-            <div class="alt-limit-title">Single Go binary, zero runtime deps</div>
+            <div class="alt-limit-title">
+              Single Go binary, zero runtime deps
+            </div>
             <p class="alt-limit-desc">
-              EMQX bundles the Erlang/OTP runtime. FluxMQ is a single compiled Go
-              binary. No runtime to configure, no OTP distribution protocol,
+              EMQX bundles the Erlang/OTP runtime. FluxMQ is a single compiled
+              Go binary. No runtime to configure, no OTP distribution protocol,
               no node cookies. Drop it in and run.
             </p>
           </div>
           <div class="alt-limit-item">
-            <div class="alt-limit-title">Durable queues in the open edition</div>
+            <div class="alt-limit-title">
+              Durable queues in the open edition
+            </div>
             <p class="alt-limit-desc">
               Consumer groups, offset tracking, dead-letter queues, and
               Kafka-style retention are in FluxMQ's Apache 2.0 release — not
@@ -358,9 +364,7 @@ const faqSchema = JSON.stringify({
     <section class="section">
       <div class="container-narrow" style="text-align:center;">
         <span class="kicker">Get started</span>
-        <h2 class="h-2" style="margin-top:14px;">
-          Try FluxMQ.
-        </h2>
+        <h2 class="h-2" style="margin-top:14px;">Try FluxMQ.</h2>
         <p class="lede" style="margin:20px auto 36px;">
           Open source, Apache 2.0, single Go binary. Run it with Docker Compose
           in under five minutes.

--- a/src/pages/emqx-alternative.astro
+++ b/src/pages/emqx-alternative.astro
@@ -1,0 +1,573 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import FAQAccordion from "../components/FAQAccordion.astro";
+
+const comparisonRows = [
+  {
+    feature: "MQTT 3.1.1 & 5.0",
+    fluxmq: "Yes",
+    emqx: "Yes",
+  },
+  {
+    feature: "AMQP 0.9.1",
+    fluxmq: "Yes",
+    emqx: "No",
+  },
+  {
+    feature: "AMQP 1.0",
+    fluxmq: "Yes",
+    emqx: "No",
+  },
+  {
+    feature: "CoAP bridge",
+    fluxmq: "Yes",
+    emqx: "Yes (plugin)",
+  },
+  {
+    feature: "Built-in clustering",
+    fluxmq: "Yes (embedded etcd)",
+    emqx: "Yes (Erlang distribution)",
+  },
+  {
+    feature: "Durable queues with consumer groups",
+    fluxmq: "Yes",
+    emqx: "Enterprise edition only",
+  },
+  {
+    feature: "Dead-letter queues",
+    fluxmq: "Yes",
+    emqx: "Enterprise edition only",
+  },
+  {
+    feature: "Single binary, no runtime deps",
+    fluxmq: "Yes (Go binary)",
+    emqx: "No (Erlang/OTP runtime bundled)",
+  },
+  {
+    feature: "License",
+    fluxmq: "Apache 2.0 (all features)",
+    emqx: "Apache 2.0 (community) / Commercial (enterprise)",
+  },
+  {
+    feature: "Implementation language",
+    fluxmq: "Go",
+    emqx: "Erlang/OTP",
+  },
+];
+
+const faqs = [
+  {
+    q: "What is the main difference between FluxMQ and EMQX?",
+    a: "FluxMQ is a single Go binary with no external runtime dependencies and ships all features — clustering, durable queues, AMQP support — under Apache 2.0. EMQX is a well-established Erlang broker with a large community edition and a separate enterprise edition that unlocks features like advanced rule engines and data persistence. FluxMQ targets teams that want full capability under a single open-source license without a commercial upgrade path.",
+  },
+  {
+    q: "Does FluxMQ support AMQP like EMQX?",
+    a: "FluxMQ supports both AMQP 0.9.1 and AMQP 1.0 natively. EMQX does not have native AMQP support — it is an MQTT broker. If your architecture needs to bridge MQTT IoT devices with AMQP-based enterprise services, FluxMQ handles both protocols on the same broker core.",
+  },
+  {
+    q: "Is EMQX Community Edition fully open source?",
+    a: "Yes, EMQX Community Edition is Apache 2.0. However, certain enterprise-grade features — including advanced data bridging, durable queue persistence, and priority support — are only available in EMQX Enterprise, which is commercially licensed.",
+  },
+  {
+    q: "Is FluxMQ suitable for the same scale as EMQX?",
+    a: "FluxMQ targets high-throughput IoT deployments: 500K+ concurrent connections and 300K–500K messages/sec per node, scaling linearly with cluster size. EMQX is also designed for large-scale deployments. Teams should evaluate both against their specific workload characteristics.",
+  },
+  {
+    q: "How difficult is it to operate FluxMQ compared to EMQX?",
+    a: "FluxMQ is a single Go binary. Configuration is a YAML file. No Erlang runtime, no node cookie management, no OTP distribution protocol tuning. For teams not already running Erlang infrastructure, the operational surface is significantly smaller.",
+  },
+  {
+    q: "Which should I choose for an IoT platform like Magistrala?",
+    a: "Both can serve as the message broker for an IoT platform. FluxMQ is the recommended broker for Magistrala deployments — it integrates with Magistrala's device identity and RBAC layer out of the box and is developed by the same team.",
+  },
+];
+
+const faqSchema = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map(({ q, a }) => ({
+    "@type": "Question",
+    name: q,
+    acceptedAnswer: { "@type": "Answer", text: a },
+  })),
+});
+---
+
+<BaseLayout
+  title="EMQX Alternative — FluxMQ MQTT Broker | Apache 2.0"
+  description="Looking for an open-source EMQX alternative? FluxMQ is Apache 2.0 with no enterprise tier — MQTT 5.0, AMQP 0.9.1 & 1.0, built-in clustering, durable queues, and a single Go binary with zero external dependencies."
+>
+  <Header />
+  <main>
+    <!-- Hero -->
+    <section class="page-hero">
+      <div class="container-wide">
+        <div class="hero-copy" style="max-width:700px;">
+          <span class="kicker">EMQX Alternative</span>
+          <h1 class="h-1" style="margin-top:14px; max-width:18ch;">
+            The open-source EMQX alternative with no enterprise tier.
+          </h1>
+          <p class="lede" style="margin-top:20px; max-width:52ch;">
+            EMQX is a mature MQTT broker. FluxMQ ships clustering, durable queues,
+            AMQP support, and 500K+ connections per node — all under Apache 2.0
+            with no features locked behind a commercial edition.
+          </p>
+          <div class="btn-row" style="margin-top:32px;">
+            <a href="/products/fluxmq" class="btn btn-primary">
+              FluxMQ Product Page →
+            </a>
+            <a
+              href="https://github.com/absmach/fluxmq"
+              class="btn"
+              target="_blank"
+              rel="noopener">GitHub ↗</a
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Featured snippet -->
+    <section class="section" style="border-bottom:1px solid var(--line-3);">
+      <div class="container-wide">
+        <div class="alt-definition-block">
+          <h2 class="alt-definition-h2">
+            Why do teams look for an EMQX alternative?
+          </h2>
+          <p class="alt-definition-text">
+            EMQX Community Edition is Apache 2.0 but several production-grade
+            capabilities — including durable queue persistence, advanced data
+            bridging, and priority support — require EMQX Enterprise, which is
+            commercially licensed. Teams that want full feature access under a
+            single open-source license often evaluate FluxMQ or other
+            Apache-licensed brokers.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- What EMQX is good at -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Context</span>
+            <h2 class="h-2" style="margin-top:14px;">What EMQX is good at.</h2>
+          </div>
+          <p class="lede">
+            EMQX is a production-proven MQTT broker used by organisations
+            globally. It has a large ecosystem and strong enterprise support.
+          </p>
+        </div>
+        <div class="alt-pros-grid">
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Mature clustering</div>
+            <p class="alt-pro-desc">
+              EMQX's Erlang-based distribution layer is battle-tested for
+              large-scale multi-node deployments.
+            </p>
+          </div>
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Large plugin ecosystem</div>
+            <p class="alt-pro-desc">
+              Extensive rule engine, data bridge connectors, and authentication
+              plugins available in the enterprise edition.
+            </p>
+          </div>
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Active community</div>
+            <p class="alt-pro-desc">
+              Large user base, extensive documentation, and regular releases
+              backed by EMQ Technologies.
+            </p>
+          </div>
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Dashboard UI</div>
+            <p class="alt-pro-desc">
+              EMQX ships a web dashboard for monitoring connections, topics,
+              and subscriptions.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Where FluxMQ fits -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Differentiators</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              Where FluxMQ is different.
+            </h2>
+          </div>
+        </div>
+        <div class="alt-limit-grid">
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">AMQP 0.9.1 & 1.0 on the same broker</div>
+            <p class="alt-limit-desc">
+              EMQX is an MQTT broker. FluxMQ natively speaks MQTT, AMQP 0.9.1,
+              AMQP 1.0, CoAP, and HTTP-MQTT — all routing through the same Queue
+              Manager. No separate broker for enterprise AMQP services.
+            </p>
+          </div>
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">Single Go binary, zero runtime deps</div>
+            <p class="alt-limit-desc">
+              EMQX bundles the Erlang/OTP runtime. FluxMQ is a single compiled Go
+              binary. No runtime to configure, no OTP distribution protocol,
+              no node cookies. Drop it in and run.
+            </p>
+          </div>
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">Durable queues in the open edition</div>
+            <p class="alt-limit-desc">
+              Consumer groups, offset tracking, dead-letter queues, and
+              Kafka-style retention are in FluxMQ's Apache 2.0 release — not
+              locked behind a commercial tier.
+            </p>
+          </div>
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">Embedded etcd for coordination</div>
+            <p class="alt-limit-desc">
+              FluxMQ uses embedded etcd for cluster coordination and gRPC with
+              mTLS for inter-broker communication. No Erlang distribution
+              protocol tuning needed to build a cluster.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Comparison</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              FluxMQ vs EMQX — feature by feature.
+            </h2>
+          </div>
+        </div>
+        <div class="alt-table-wrap">
+          <table class="alt-table">
+            <thead>
+              <tr>
+                <th>Feature</th>
+                <th class="alt-col-fluxmq">FluxMQ</th>
+                <th>EMQX Community</th>
+              </tr>
+            </thead>
+            <tbody>
+              {
+                comparisonRows.map(({ feature, fluxmq, emqx }) => (
+                  <tr>
+                    <td>{feature}</td>
+                    <td class="alt-col-fluxmq alt-yes">{fluxmq}</td>
+                    <td
+                      class={
+                        emqx === "No"
+                          ? "alt-no"
+                          : emqx === "Yes"
+                            ? "alt-yes"
+                            : "alt-partial"
+                      }
+                    >
+                      {emqx}
+                    </td>
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
+        </div>
+        <p
+          style="font-size:12px; color:var(--ink-4); margin-top:12px; line-height:1.6;"
+        >
+          Sources: EMQX documentation (emqx.com/docs), FluxMQ source code and
+          documentation (github.com/absmach/fluxmq). EMQX Enterprise features
+          based on publicly documented Enterprise Edition capabilities.
+        </p>
+      </div>
+    </section>
+
+    <!-- Performance bar -->
+    <section
+      style="background:var(--surface-accent); color:var(--on-accent); padding:80px 0;"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker" style="color:var(--on-accent-muted);"
+              >FluxMQ</span
+            >
+            <h2 class="h-1" style="margin-top:14px; color:var(--on-accent);">
+              Apache 2.0. All features. One binary.
+            </h2>
+          </div>
+          <p class="lede" style="color:var(--on-accent-dim); max-width:36ch;">
+            No enterprise edition. No feature flags. No commercial upgrade path.
+            Everything ships in the open-source release.
+          </p>
+        </div>
+        <div class="alt-highlights-grid">
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">MQTT 5.0</div>
+            <div class="alt-highlight-l">+ AMQP 0.9.1 & 1.0 + CoAP</div>
+          </div>
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">500K+</div>
+            <div class="alt-highlight-l">Concurrent connections / node</div>
+          </div>
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">Consumer groups</div>
+            <div class="alt-highlight-l">+ DLQ + Kafka-style retention</div>
+          </div>
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">Apache 2.0</div>
+            <div class="alt-highlight-l">All features, no commercial tier</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">FAQ</span>
+            <h2 class="h-2" style="margin-top:14px;">Common questions.</h2>
+          </div>
+        </div>
+        <FAQAccordion items={faqs} />
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="section">
+      <div class="container-narrow" style="text-align:center;">
+        <span class="kicker">Get started</span>
+        <h2 class="h-2" style="margin-top:14px;">
+          Try FluxMQ.
+        </h2>
+        <p class="lede" style="margin:20px auto 36px;">
+          Open source, Apache 2.0, single Go binary. Run it with Docker Compose
+          in under five minutes.
+        </p>
+        <div class="btn-row" style="justify-content:center;">
+          <a
+            href="https://github.com/absmach/fluxmq"
+            class="btn btn-primary"
+            target="_blank"
+            rel="noopener">View on GitHub ↗</a
+          >
+          <a
+            href="https://www.absmach.eu/docs/fluxmq"
+            class="btn"
+            target="_blank"
+            rel="noopener">Documentation ↗</a
+          >
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <script is:inline type="application/ld+json" set:html={faqSchema} />
+  <script type="application/ld+json" is:inline>
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.absmach.eu/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "EMQX Alternative",
+          "item": "https://www.absmach.eu/emqx-alternative"
+        }
+      ]
+    }
+  </script>
+</BaseLayout>
+
+<style>
+  .alt-definition-block {
+    background: var(--paper-2);
+    border: 1px solid var(--line-3);
+    border-left: 4px solid var(--ink);
+    border-radius: var(--radius-lg);
+    padding: 32px 40px;
+    max-width: 820px;
+  }
+  .alt-definition-h2 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 14px;
+  }
+  .alt-definition-text {
+    font-size: 16px;
+    line-height: 1.7;
+    color: var(--ink-2);
+    margin: 0;
+  }
+
+  .alt-pros-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-top: 48px;
+  }
+  .alt-pro-card {
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    background: var(--paper-2);
+  }
+  .alt-pro-title {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ink);
+    margin-bottom: 8px;
+  }
+  .alt-pro-desc {
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  .alt-limit-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    margin-top: 48px;
+  }
+  .alt-limit-item {
+    border-left: 3px solid var(--line-2);
+    padding-left: 20px;
+  }
+  .alt-limit-title {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ink);
+    margin-bottom: 8px;
+  }
+  .alt-limit-desc {
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  .alt-table-wrap {
+    overflow-x: auto;
+    margin-top: 48px;
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+  }
+  .alt-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .alt-table th {
+    padding: 14px 20px;
+    text-align: left;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-3);
+    border-bottom: 1px solid var(--line-3);
+    background: var(--paper-2);
+  }
+  .alt-table td {
+    padding: 13px 20px;
+    border-bottom: 1px solid var(--line-3);
+    color: var(--ink-2);
+    font-size: 13px;
+  }
+  .alt-table tr:last-child td {
+    border-bottom: none;
+  }
+  .alt-table td:first-child {
+    color: var(--ink);
+    font-weight: 500;
+  }
+  .alt-col-fluxmq {
+    background: rgba(7, 55, 99, 0.03);
+  }
+  .alt-yes {
+    color: var(--ink) !important;
+    font-weight: 600 !important;
+  }
+  .alt-no {
+    color: var(--ink-3) !important;
+  }
+  .alt-partial {
+    color: var(--ink-2) !important;
+  }
+
+  .alt-highlights-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    margin-top: 48px;
+  }
+  .alt-highlight {
+    background: rgba(255, 255, 255, 0.04);
+    padding: 32px 24px;
+    text-align: center;
+  }
+  .alt-highlight-v {
+    font-family: "Montserrat", sans-serif;
+    font-weight: 700;
+    font-size: 24px;
+    color: var(--on-accent);
+    margin-bottom: 8px;
+  }
+  .alt-highlight-l {
+    font-size: 13px;
+    color: var(--on-accent-dim);
+    line-height: 1.4;
+  }
+
+  @media (max-width: 980px) {
+    .alt-highlights-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (max-width: 640px) {
+    .alt-pros-grid,
+    .alt-limit-grid {
+      grid-template-columns: 1fr;
+    }
+    .alt-highlights-grid {
+      grid-template-columns: 1fr;
+    }
+    .alt-definition-block {
+      padding: 24px;
+    }
+  }
+</style>

--- a/src/pages/iiot-platform-architecture.astro
+++ b/src/pages/iiot-platform-architecture.astro
@@ -1,0 +1,1016 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import FAQAccordion from "../components/FAQAccordion.astro";
+
+const layers = [
+  {
+    num: "01",
+    name: "Device & Sensor Layer",
+    desc: "Physical endpoints — PLCs, RTUs, sensors, meters, actuators, and embedded modules. Devices communicate over field protocols (Modbus, OPC-UA, Wireless M-Bus, BACnet) or directly over IP (MQTT, CoAP, HTTP).",
+    products: [],
+    keywords: ["microcontrollers", "PLCs", "RTUs", "sensors", "Modbus", "OPC-UA"],
+  },
+  {
+    num: "02",
+    name: "Connectivity & Edge Gateway Layer",
+    desc: "Edge gateways aggregate device traffic, translate protocols, and act as the first hop toward the cloud. They run local logic to reduce bandwidth, filter noise, and operate offline when connectivity is lost.",
+    products: [
+      { name: "A0 Gateway", href: "/products/a0", desc: "ESP32-C6 RISC-V module with 6 native radios" },
+      { name: "A1 Gateway", href: "/products/a1", desc: "RISC-V Linux gateway for heavier workloads" },
+    ],
+    keywords: ["protocol gateway", "edge computing", "protocol translation", "offline operation"],
+  },
+  {
+    num: "03",
+    name: "Message Broker & Transport Layer",
+    desc: "The message broker decouples device producers from platform consumers. MQTT is the dominant protocol for constrained devices; AMQP bridges enterprise services. High-availability brokers with durable queues prevent data loss during outages.",
+    products: [
+      { name: "FluxMQ", href: "/products/fluxmq", desc: "Enterprise MQTT 5.0 + AMQP broker, built-in clustering" },
+    ],
+    keywords: ["MQTT broker", "message queue", "AMQP", "publish-subscribe", "QoS"],
+  },
+  {
+    num: "04",
+    name: "IoT Platform & Device Management Layer",
+    desc: "The platform manages device identity, telemetry ingestion, rules processing, dashboards, and multi-tenant access control. It is the operational core that operators interact with daily.",
+    products: [
+      { name: "Magistrala", href: "/products/magistrala", desc: "Open-source IoT platform with RBAC, dashboards, rules engine" },
+    ],
+    keywords: ["device management", "telemetry", "dashboards", "rules engine", "multi-tenancy"],
+  },
+  {
+    num: "05",
+    name: "Identity & Authorization Layer",
+    desc: "Every device, user, and service must be authenticated and authorized before accessing resources. Runtime policy evaluation prevents stale-permission windows that occur when permissions are embedded in tokens.",
+    products: [
+      { name: "Atom", href: "/products/atom", desc: "Open-source IAM with runtime RBAC/ABAC for IoT" },
+    ],
+    keywords: ["device identity", "IAM", "RBAC", "ABAC", "JWT", "authorization"],
+  },
+  {
+    num: "06",
+    name: "Edge Compute & Orchestration Layer",
+    desc: "WebAssembly workloads can be deployed and updated remotely on both cloud nodes and microcontrollers. This layer enables AI inference, data transformation, and protocol bridging at the edge without firmware reflashing.",
+    products: [
+      { name: "Propeller", href: "/products/propeller", desc: "WebAssembly edge orchestrator, cloud-to-MCU" },
+    ],
+    keywords: ["WebAssembly", "edge AI", "FaaS", "OTA updates", "Wasm orchestration"],
+  },
+  {
+    num: "07",
+    name: "Security & Cryptography Layer",
+    desc: "Long-lived IoT devices must remain secure after classical PKI is broken by quantum computers. Hardware-accelerated post-quantum cryptography provides forward-secure device identity that outlives the deployment lifetime.",
+    products: [
+      { name: "Quarc", href: "/products/quarc", desc: "Post-quantum secure element, ML-KEM & ML-DSA" },
+    ],
+    keywords: ["post-quantum cryptography", "secure element", "hardware root of trust", "ML-KEM", "ML-DSA"],
+  },
+];
+
+const protocols = [
+  {
+    name: "MQTT",
+    full: "Message Queuing Telemetry Transport",
+    version: "3.1.1 / 5.0",
+    use: "Primary IoT telemetry protocol. Lightweight publish-subscribe with QoS 0/1/2, retained messages, and Last Will. MQTT 5.0 adds shared subscriptions, flow control, and user properties.",
+    transport: "TCP / WebSocket",
+  },
+  {
+    name: "AMQP",
+    full: "Advanced Message Queuing Protocol",
+    version: "0.9.1 / 1.0",
+    use: "Enterprise message queuing. Used for integrating IoT data streams with ERP, MES, and cloud services. Supports transactions, routing topologies, and dead-letter queues.",
+    transport: "TCP",
+  },
+  {
+    name: "CoAP",
+    full: "Constrained Application Protocol",
+    version: "RFC 7252",
+    use: "REST-like protocol optimised for constrained devices with limited bandwidth. Runs over UDP, includes DTLS for security. Common in smart metering and sensor networks.",
+    transport: "UDP / DTLS",
+  },
+  {
+    name: "OPC-UA",
+    full: "Open Platform Communications Unified Architecture",
+    version: "—",
+    use: "Industrial automation standard for PLC and SCADA integration. Rich information model, complex address space, and built-in security. Common in manufacturing and process control.",
+    transport: "TCP / WebSocket",
+  },
+  {
+    name: "Modbus",
+    full: "Modbus RTU / TCP",
+    version: "—",
+    use: "Ubiquitous serial protocol in industrial automation. Runs over RS-485 (RTU) or Ethernet (TCP). No built-in security — requires gateway-level encryption for remote access.",
+    transport: "RS-485 / TCP",
+  },
+  {
+    name: "Wireless M-Bus",
+    full: "EN 13757",
+    version: "868 MHz",
+    use: "European standard for wireless utility meter reading. Used for smart metering of electricity, gas, heat, and water. Operates at 868 MHz sub-GHz for range and wall penetration.",
+    transport: "868 MHz RF",
+  },
+];
+
+const faqs = [
+  {
+    q: "What is IIoT platform architecture?",
+    a: "IIoT platform architecture describes how industrial IoT systems are structured — the layers, components, and protocols that connect physical devices to cloud applications. A typical architecture includes device and sensor layers, edge gateways, message brokers, an IoT platform for device management and dashboards, an identity and authorization layer, and optional edge compute and cryptography layers.",
+  },
+  {
+    q: "What is the difference between IoT and IIoT?",
+    a: "IoT (Internet of Things) is the broad category of connected devices — consumer electronics, smart home devices, wearables. IIoT (Industrial Internet of Things) specifically refers to connected devices in industrial contexts: manufacturing, energy, utilities, transportation, and infrastructure. IIoT systems typically have higher reliability requirements, longer device lifetimes, and stricter security and compliance needs.",
+  },
+  {
+    q: "Why is MQTT the dominant protocol for IIoT?",
+    a: "MQTT was designed for constrained devices over unreliable networks. Its publish-subscribe model decouples producers from consumers. Quality of Service levels (0/1/2) provide flexible delivery guarantees. It runs over TCP with minimal overhead, making it suitable for everything from microcontrollers to cloud-scale brokers. MQTT 5.0 adds features like shared subscriptions, topic aliases, and enhanced authentication that enterprise deployments need.",
+  },
+  {
+    q: "What is an IoT gateway and do I need one?",
+    a: "An IoT gateway is a device that aggregates data from local sensors and field devices and forwards it to a cloud platform. Gateways are necessary when field devices speak non-IP protocols (Modbus, Wireless M-Bus, Bluetooth), when local processing or offline buffering is required, or when you want to reduce cloud bandwidth by aggregating and filtering data at the edge. For devices with native IP and MQTT support, a gateway is optional.",
+  },
+  {
+    q: "How does edge computing fit into IIoT architecture?",
+    a: "Edge computing moves processing from the cloud to the device or gateway. In IIoT this reduces latency for time-critical control loops, lowers cloud bandwidth costs, and enables operation during cloud connectivity loss. Edge compute layers typically run lightweight runtimes — containers, WebAssembly, or native binaries — on gateway hardware. WebAssembly is increasingly used because it provides sandboxed isolation, sub-10ms startup, and portability from cloud servers down to microcontrollers.",
+  },
+  {
+    q: "What is a message broker in IIoT architecture?",
+    a: "A message broker is the central routing component for device telemetry. Devices publish messages to topics; platform services subscribe to those topics. The broker decouples producers from consumers, handles delivery guarantees (QoS), and can buffer messages during downstream failures. In enterprise IIoT, brokers also provide durable queues with consumer groups so multiple downstream services can consume the same data stream independently.",
+  },
+  {
+    q: "How should IoT device identity be managed?",
+    a: "Each device needs a unique cryptographic identity — typically a certificate or API key associated with a device record in the platform. That identity controls which topics the device can publish and subscribe to. Runtime policy evaluation (rather than token-embedded permissions) ensures that when a device is decommissioned or its credentials are revoked, access is blocked immediately without waiting for tokens to expire.",
+  },
+  {
+    q: "Why does post-quantum cryptography matter for IIoT now?",
+    a: "Industrial devices deployed today often remain in the field for 10–20 years. Quantum computers capable of breaking ECC and RSA are projected to become practical within that window. NIST finalised post-quantum cryptography standards in 2024. EU and US regulators project mandatory PQC adoption in critical infrastructure by 2030. Devices that ship now with only classical cryptography will be vulnerable before end-of-life.",
+  },
+];
+
+const faqSchema = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map(({ q, a }) => ({
+    "@type": "Question",
+    name: q,
+    acceptedAnswer: { "@type": "Answer", text: a },
+  })),
+});
+---
+
+<BaseLayout
+  title="IIoT Platform Architecture Explained — Complete Guide"
+  description="A complete guide to Industrial IoT platform architecture. Understand the device, connectivity, message broker, platform, identity, edge compute, and security layers — with protocol comparisons and open-source implementation examples."
+>
+  <Header />
+  <main>
+    <!-- Hero -->
+    <section
+      class="page-hero"
+      style="padding-top:80px; padding-bottom:80px; background:var(--surface-accent); color:var(--on-accent);"
+    >
+      <div class="container-wide">
+        <div class="hero-copy" style="max-width:760px;">
+          <span
+            class="kicker"
+            style="color:rgba(246,244,238,0.55); margin-bottom:16px; display:block;"
+            >IIoT Architecture Guide</span
+          >
+          <h1
+            class="h-1"
+            style="color:var(--on-accent); margin-top:14px; max-width:18ch;"
+          >
+            Industrial IoT Platform Architecture: Layers, Protocols, and
+            Components Explained.
+          </h1>
+          <p class="lede" style="color:var(--on-accent-dim); max-width:60ch;">
+            A practical guide to how industrial IoT systems are structured —
+            from sensor to cloud, including edge computing, device identity, and
+            post-quantum security.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Featured snippet — definition block -->
+    <section class="section" style="border-bottom:1px solid var(--line-3);">
+      <div class="container-wide">
+        <div class="pillar-definition-block">
+          <h2 class="pillar-definition-h2">What is IIoT platform architecture?</h2>
+          <p class="pillar-definition-text">
+            IIoT platform architecture describes how industrial IoT systems are
+            structured across multiple layers: physical devices and sensors, edge
+            gateways for local processing, a message broker for telemetry
+            transport, a central IoT platform for device management and dashboards,
+            and identity and security layers. Each layer has defined
+            responsibilities, protocols, and scaling characteristics.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Architecture layers -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Architecture</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              The seven layers of IIoT platform architecture.
+            </h2>
+          </div>
+          <p class="lede">
+            Industrial IoT systems are built from distinct functional layers.
+            Understanding each layer's role helps you choose the right
+            components and avoid common design pitfalls.
+          </p>
+        </div>
+        <div class="pillar-layers">
+          {
+            layers.map(({ num, name, desc, products, keywords }) => (
+              <div class="pillar-layer">
+                <div class="pillar-layer-num">{num}</div>
+                <div class="pillar-layer-body">
+                  <h3 class="pillar-layer-name">{name}</h3>
+                  <p class="pillar-layer-desc">{desc}</p>
+                  {keywords.length > 0 && (
+                    <div class="pillar-layer-tags">
+                      {keywords.map((k) => (
+                        <span class="pillar-tag">{k}</span>
+                      ))}
+                    </div>
+                  )}
+                  {products.length > 0 && (
+                    <div class="pillar-layer-products">
+                      <span class="pillar-layer-products-label">
+                        Abstract Machines:
+                      </span>
+                      {products.map(({ name: pname, href, desc: pdesc }) => (
+                        <a href={href} class="pillar-product-link">
+                          <strong>{pname}</strong> — {pdesc}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Architecture diagram / stack -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Stack overview</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              How the Abstract Machines stack maps to each layer.
+            </h2>
+          </div>
+          <p class="lede">
+            Each product addresses a specific architectural layer. They can be
+            deployed individually or as an integrated stack.
+          </p>
+        </div>
+        <div class="pillar-stack">
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Applications & Dashboards</div>
+            <div class="pillar-stack-product">
+              <a href="/products/magistrala">Magistrala</a> — visual dashboards,
+              alarm management, reports, rules engine
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Device Management & Platform</div>
+            <div class="pillar-stack-product">
+              <a href="/products/magistrala">Magistrala</a> — device provisioning,
+              channel management, multi-tenancy, SDKs
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Identity & Authorization</div>
+            <div class="pillar-stack-product">
+              <a href="/products/atom">Atom</a> — runtime RBAC/ABAC, JWT, OIDC, device
+              credentials, policy engine
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Message Transport</div>
+            <div class="pillar-stack-product">
+              <a href="/products/fluxmq">FluxMQ</a> — MQTT 5.0, AMQP, CoAP, durable
+              queues, 500K+ connections/node
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Edge Compute & Orchestration</div>
+            <div class="pillar-stack-product">
+              <a href="/products/propeller">Propeller</a> — WebAssembly orchestrator,
+              OCI registry, FaaS at the edge, Zephyr support
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Edge Gateway (Linux)</div>
+            <div class="pillar-stack-product">
+              <a href="/products/a1">A1 Gateway</a> — RISC-V Linux, containers, Wasm,
+              EU-manufactured
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Edge Gateway (RTOS / MCU)</div>
+            <div class="pillar-stack-product">
+              <a href="/products/a0">A0 Gateway</a> — ESP32-C6 RISC-V, Zephyr, 6
+              radios (Wi-Fi 6, BLE, NB-IoT, M-Bus, Thread, Ethernet)
+            </div>
+          </div>
+          <div class="pillar-stack-row">
+            <div class="pillar-stack-label">Hardware Security</div>
+            <div class="pillar-stack-product">
+              <a href="/products/quarc">Quarc</a> — post-quantum secure element,
+              ML-KEM-768, ML-DSA-65, hardware root of trust
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Protocols -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Protocols</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              IIoT protocols: which to use and when.
+            </h2>
+          </div>
+          <p class="lede">
+            Protocol selection depends on device constraints, network
+            conditions, data volume, and integration requirements. Most
+            production deployments use multiple protocols.
+          </p>
+        </div>
+        <div class="pillar-proto-grid">
+          {
+            protocols.map(({ name, full, version, use, transport }) => (
+              <div class="pillar-proto-card">
+                <div class="pillar-proto-header">
+                  <span class="pillar-proto-name">{name}</span>
+                  <span class="pillar-proto-transport">{transport}</span>
+                </div>
+                <div class="pillar-proto-full">{full}</div>
+                {version !== "—" && (
+                  <div class="pillar-proto-version">{version}</div>
+                )}
+                <p class="pillar-proto-use">{use}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Edge vs Cloud -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Design decisions</span>
+            <h2 class="h-2" style="margin-top:14px;">Edge vs cloud processing.</h2>
+          </div>
+          <p class="lede">
+            The decision of where to process data has significant implications
+            for latency, bandwidth costs, offline resilience, and security.
+          </p>
+        </div>
+        <div class="pillar-edge-grid">
+          <div class="pillar-edge-card">
+            <h3 class="pillar-edge-title">Process at the edge when:</h3>
+            <ul class="pillar-edge-list">
+              <li>
+                Control loops require sub-100ms response times (cloud round-trips
+                introduce too much latency)
+              </li>
+              <li>
+                Devices operate in locations with intermittent connectivity —
+                local processing must continue offline
+              </li>
+              <li>
+                Data volume is high but only aggregates or anomalies are
+                relevant to the cloud (bandwidth reduction)
+              </li>
+              <li>
+                Data sovereignty or regulatory requirements restrict transmission
+                of raw device data off-premises
+              </li>
+              <li>
+                AI inference must run close to the sensor to be actionable (e.g.
+                real-time vision, predictive maintenance)
+              </li>
+            </ul>
+          </div>
+          <div class="pillar-edge-card">
+            <h3 class="pillar-edge-title">Process in the cloud when:</h3>
+            <ul class="pillar-edge-list">
+              <li>
+                Long-term storage and historical analysis are the primary use case
+                — cloud storage is cheaper and more scalable
+              </li>
+              <li>
+                Cross-site correlation is needed — aggregating data from hundreds
+                of sites for fleet-level analytics
+              </li>
+              <li>
+                Heavy ML training runs that require GPU resources not available at
+                the edge
+              </li>
+              <li>
+                Compliance reporting and audit trails that must be tamper-proof and
+                centrally managed
+              </li>
+              <li>
+                Real-time dashboards and alerting that operators access from
+                anywhere
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Security section -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Security</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              IIoT security architecture.
+            </h2>
+          </div>
+          <p class="lede">
+            Industrial IoT systems have distinct security requirements compared
+            to consumer IoT. Devices are long-lived, operate in physical
+            environments, and often control critical infrastructure.
+          </p>
+        </div>
+        <div class="pillar-security-grid">
+          <div class="pillar-security-item">
+            <h3 class="pillar-security-name">Device identity</h3>
+            <p class="pillar-security-desc">
+              Every device needs a unique cryptographic identity issued at
+              manufacture or provisioning. Device certificates or API keys
+              authenticate the device to the message broker and platform. When
+              a device is decommissioned, its credentials must be revoked and
+              access blocked immediately — runtime policy evaluation (not
+              token-embedded permissions) guarantees this.
+            </p>
+            <a href="/products/atom" class="btn-link" style="font-size:13px;"
+              >Atom — runtime IAM →</a
+            >
+          </div>
+          <div class="pillar-security-item">
+            <h3 class="pillar-security-name">Transport security</h3>
+            <p class="pillar-security-desc">
+              All device-to-broker and broker-to-platform communication should
+              be encrypted. TLS 1.2+ for MQTT and HTTPS. mTLS for inter-service
+              communication. DTLS for CoAP over UDP. For constrained devices
+              where TLS is too heavy, lighter alternatives exist but increase
+              risk — the gateway should terminate TLS on behalf of downstream
+              devices.
+            </p>
+          </div>
+          <div class="pillar-security-item">
+            <h3 class="pillar-security-name">Secure boot & OTA updates</h3>
+            <p class="pillar-security-desc">
+              Firmware must be signed and the signature verified at boot before
+              execution. OTA updates must be delivered over authenticated, encrypted
+              channels and must include rollback protection — a failed update
+              must not brick the device or leave it in an unknown state.
+            </p>
+            <a
+              href="/products/quarc"
+              class="btn-link"
+              style="font-size:13px;"
+            >
+              Quarc — hardware-enforced secure boot →
+            </a>
+          </div>
+          <div class="pillar-security-item">
+            <h3 class="pillar-security-name">Post-quantum preparedness</h3>
+            <p class="pillar-security-desc">
+              Industrial devices deployed today may be in the field when quantum
+              computers become capable of breaking ECC and RSA. NIST finalised
+              post-quantum cryptography standards in 2024 (FIPS 203, 204, 205).
+              New designs should evaluate ML-KEM (key encapsulation) and ML-DSA
+              (signatures) for device identity and firmware signing, especially
+              for devices with 10+ year deployment lifetimes.
+            </p>
+            <a
+              href="/products/quarc"
+              class="btn-link"
+              style="font-size:13px;"
+            >
+              Quarc — PQC secure element →
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">FAQ</span>
+            <h2 class="h-2" style="margin-top:14px;">Common questions.</h2>
+          </div>
+        </div>
+        <FAQAccordion items={faqs} />
+      </div>
+    </section>
+
+    <!-- Products CTA grid -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Abstract Machines Products</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              Open-source components for every layer.
+            </h2>
+          </div>
+          <p class="lede">
+            Abstract Machines builds open-source infrastructure for each layer
+            of the IIoT stack. All products are Apache 2.0.
+          </p>
+        </div>
+        <div class="pillar-products-grid">
+          <a href="/products/magistrala" class="pillar-product-card">
+            <div class="pillar-product-name">Magistrala</div>
+            <div class="pillar-product-layer">IoT Platform</div>
+            <p class="pillar-product-desc">
+              Multi-protocol IoT platform with device management, visual
+              dashboards, rules engine, and RBAC.
+            </p>
+          </a>
+          <a href="/products/fluxmq" class="pillar-product-card">
+            <div class="pillar-product-name">FluxMQ</div>
+            <div class="pillar-product-layer">Message Broker</div>
+            <p class="pillar-product-desc">
+              Enterprise MQTT 5.0 + AMQP broker. Clustering, durable queues,
+              500K+ connections/node.
+            </p>
+          </a>
+          <a href="/products/atom" class="pillar-product-card">
+            <div class="pillar-product-name">Atom</div>
+            <div class="pillar-product-layer">Identity & Authorization</div>
+            <p class="pillar-product-desc">
+              Runtime RBAC/ABAC for IoT. Single Rust binary, PostgreSQL-backed,
+              live policy evaluation.
+            </p>
+          </a>
+          <a href="/products/propeller" class="pillar-product-card">
+            <div class="pillar-product-name">Propeller</div>
+            <div class="pillar-product-layer">Edge Compute</div>
+            <p class="pillar-product-desc">
+              WebAssembly orchestrator from cloud to Zephyr RTOS
+              microcontrollers. OCI registry, FaaS at the edge.
+            </p>
+          </a>
+          <a href="/products/a1" class="pillar-product-card">
+            <div class="pillar-product-name">A1 Gateway</div>
+            <div class="pillar-product-layer">Linux Edge Gateway</div>
+            <p class="pillar-product-desc">
+              RISC-V Linux gateway for industrial IoT. Containers, Wasm, and
+              EU-manufactured.
+            </p>
+          </a>
+          <a href="/products/a0" class="pillar-product-card">
+            <div class="pillar-product-name">A0 Gateway</div>
+            <div class="pillar-product-layer">RTOS Edge Module</div>
+            <p class="pillar-product-desc">
+              ESP32-C6 RISC-V with 6 native radios — Wi-Fi 6, BLE, NB-IoT,
+              Wireless M-Bus, Thread, Ethernet.
+            </p>
+          </a>
+          <a href="/products/quarc" class="pillar-product-card">
+            <div class="pillar-product-name">Quarc</div>
+            <div class="pillar-product-layer">PQC Secure Element</div>
+            <p class="pillar-product-desc">
+              Post-quantum cryptography secure element. Hardware-accelerated
+              ML-KEM-768 and ML-DSA-65.
+            </p>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <script is:inline type="application/ld+json" set:html={faqSchema} />
+  <script type="application/ld+json" is:inline>
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.absmach.eu/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "IIoT Platform Architecture",
+          "item": "https://www.absmach.eu/iiot-platform-architecture"
+        }
+      ]
+    }
+  </script>
+</BaseLayout>
+
+<style>
+  .pillar-definition-block {
+    background: var(--paper-2);
+    border: 1px solid var(--line-3);
+    border-left: 4px solid var(--ink);
+    border-radius: var(--radius-lg);
+    padding: 32px 40px;
+    max-width: 860px;
+  }
+  .pillar-definition-h2 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 14px;
+  }
+  .pillar-definition-text {
+    font-size: 16px;
+    line-height: 1.75;
+    color: var(--ink-2);
+    margin: 0;
+  }
+
+  /* Architecture layers */
+  .pillar-layers {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 48px;
+  }
+  .pillar-layer {
+    display: grid;
+    grid-template-columns: 64px 1fr;
+    gap: 24px;
+    padding: 28px 0;
+    border-bottom: 1px solid var(--line-3);
+    align-items: start;
+  }
+  .pillar-layer:last-child {
+    border-bottom: none;
+  }
+  .pillar-layer-num {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--ink-4);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding-top: 4px;
+  }
+  .pillar-layer-name {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 10px;
+  }
+  .pillar-layer-desc {
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--ink-2);
+    margin: 0 0 14px;
+  }
+  .pillar-layer-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+  .pillar-tag {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    color: var(--ink-3);
+    background: var(--paper-2);
+    border: 1px solid var(--line-3);
+    border-radius: 999px;
+    padding: 3px 10px;
+  }
+  .pillar-layer-products {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 8px;
+    padding: 14px 18px;
+    background: rgba(7, 55, 99, 0.03);
+    border: 1px solid rgba(7, 55, 99, 0.1);
+    border-radius: var(--radius);
+  }
+  .pillar-layer-products-label {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-4);
+    margin-bottom: 4px;
+  }
+  .pillar-product-link {
+    font-size: 13px;
+    color: var(--ink-2);
+    text-decoration: none;
+    line-height: 1.5;
+  }
+  .pillar-product-link:hover {
+    color: var(--ink);
+  }
+  .pillar-product-link strong {
+    color: var(--ink);
+  }
+
+  /* Stack diagram */
+  .pillar-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 48px;
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  .pillar-stack-row {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 0;
+    border-bottom: 1px solid var(--line-3);
+    background: var(--paper);
+  }
+  .pillar-stack-row:last-child {
+    border-bottom: none;
+  }
+  .pillar-stack-label {
+    padding: 16px 20px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ink-3);
+    background: var(--paper-2);
+    border-right: 1px solid var(--line-3);
+    display: flex;
+    align-items: center;
+  }
+  .pillar-stack-product {
+    padding: 16px 20px;
+    font-size: 13px;
+    color: var(--ink-2);
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+  }
+  .pillar-stack-product a {
+    color: var(--ink);
+    font-weight: 600;
+    text-decoration: none;
+    margin-right: 4px;
+  }
+  .pillar-stack-product a:hover {
+    text-decoration: underline;
+  }
+
+  /* Protocols */
+  .pillar-proto-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    margin-top: 48px;
+  }
+  .pillar-proto-card {
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    background: var(--paper-2);
+  }
+  .pillar-proto-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 6px;
+  }
+  .pillar-proto-name {
+    font-family: "Montserrat", sans-serif;
+    font-weight: 700;
+    font-size: 16px;
+    color: var(--ink);
+  }
+  .pillar-proto-transport {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+  .pillar-proto-full {
+    font-size: 12px;
+    color: var(--ink-3);
+    margin-bottom: 4px;
+  }
+  .pillar-proto-version {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    color: var(--ink-4);
+    margin-bottom: 12px;
+  }
+  .pillar-proto-use {
+    font-size: 13px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    margin: 12px 0 0;
+  }
+
+  /* Edge vs Cloud */
+  .pillar-edge-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin-top: 48px;
+  }
+  .pillar-edge-card {
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    padding: 28px;
+    background: var(--paper);
+  }
+  .pillar-edge-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 16px;
+  }
+  .pillar-edge-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .pillar-edge-list li {
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    padding-left: 16px;
+    position: relative;
+  }
+  .pillar-edge-list li::before {
+    content: "→";
+    position: absolute;
+    left: 0;
+    color: var(--ink-3);
+  }
+
+  /* Security */
+  .pillar-security-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    margin-top: 48px;
+  }
+  .pillar-security-item {
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    padding: 28px;
+    background: var(--paper-2);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .pillar-security-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--ink);
+    margin: 0;
+  }
+  .pillar-security-desc {
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.7;
+    margin: 0;
+    flex: 1;
+  }
+
+  /* Products grid */
+  .pillar-products-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    margin-top: 48px;
+  }
+  .pillar-product-card {
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    background: var(--paper-2);
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: border-color 0.15s ease;
+  }
+  .pillar-product-card:hover {
+    border-color: var(--ink-3);
+  }
+  .pillar-product-name {
+    font-family: "Montserrat", sans-serif;
+    font-weight: 700;
+    font-size: 16px;
+    color: var(--ink);
+  }
+  .pillar-product-layer {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-3);
+  }
+  .pillar-product-desc {
+    font-size: 13px;
+    color: var(--ink-2);
+    line-height: 1.6;
+    margin: 4px 0 0;
+  }
+
+  /* Responsive */
+  @media (max-width: 1100px) {
+    .pillar-products-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+  @media (max-width: 980px) {
+    .pillar-proto-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .pillar-edge-grid,
+    .pillar-security-grid {
+      grid-template-columns: 1fr;
+    }
+    .pillar-products-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .pillar-stack-row {
+      grid-template-columns: 180px 1fr;
+    }
+  }
+  @media (max-width: 640px) {
+    .pillar-layer {
+      grid-template-columns: 1fr;
+      gap: 12px;
+    }
+    .pillar-layer-num {
+      padding-top: 0;
+    }
+    .pillar-proto-grid {
+      grid-template-columns: 1fr;
+    }
+    .pillar-products-grid {
+      grid-template-columns: 1fr;
+    }
+    .pillar-stack-row {
+      grid-template-columns: 1fr;
+    }
+    .pillar-stack-label {
+      border-right: none;
+      border-bottom: 1px solid var(--line-3);
+      padding: 10px 16px;
+    }
+    .pillar-stack-product {
+      padding: 12px 16px;
+    }
+    .pillar-definition-block {
+      padding: 24px;
+    }
+  }
+</style>

--- a/src/pages/iiot-platform-architecture.astro
+++ b/src/pages/iiot-platform-architecture.astro
@@ -10,62 +10,133 @@ const layers = [
     name: "Device & Sensor Layer",
     desc: "Physical endpoints — PLCs, RTUs, sensors, meters, actuators, and embedded modules. Devices communicate over field protocols (Modbus, OPC-UA, Wireless M-Bus, BACnet) or directly over IP (MQTT, CoAP, HTTP).",
     products: [],
-    keywords: ["microcontrollers", "PLCs", "RTUs", "sensors", "Modbus", "OPC-UA"],
+    keywords: [
+      "microcontrollers",
+      "PLCs",
+      "RTUs",
+      "sensors",
+      "Modbus",
+      "OPC-UA",
+    ],
   },
   {
     num: "02",
     name: "Connectivity & Edge Gateway Layer",
     desc: "Edge gateways aggregate device traffic, translate protocols, and act as the first hop toward the cloud. They run local logic to reduce bandwidth, filter noise, and operate offline when connectivity is lost.",
     products: [
-      { name: "A0 Gateway", href: "/products/a0", desc: "ESP32-C6 RISC-V module with 6 native radios" },
-      { name: "A1 Gateway", href: "/products/a1", desc: "RISC-V Linux gateway for heavier workloads" },
+      {
+        name: "A0 Gateway",
+        href: "/products/a0",
+        desc: "ESP32-C6 RISC-V module with 6 native radios",
+      },
+      {
+        name: "A1 Gateway",
+        href: "/products/a1",
+        desc: "RISC-V Linux gateway for heavier workloads",
+      },
     ],
-    keywords: ["protocol gateway", "edge computing", "protocol translation", "offline operation"],
+    keywords: [
+      "protocol gateway",
+      "edge computing",
+      "protocol translation",
+      "offline operation",
+    ],
   },
   {
     num: "03",
     name: "Message Broker & Transport Layer",
     desc: "The message broker decouples device producers from platform consumers. MQTT is the dominant protocol for constrained devices; AMQP bridges enterprise services. High-availability brokers with durable queues prevent data loss during outages.",
     products: [
-      { name: "FluxMQ", href: "/products/fluxmq", desc: "Enterprise MQTT 5.0 + AMQP broker, built-in clustering" },
+      {
+        name: "FluxMQ",
+        href: "/products/fluxmq",
+        desc: "Enterprise MQTT 5.0 + AMQP broker, built-in clustering",
+      },
     ],
-    keywords: ["MQTT broker", "message queue", "AMQP", "publish-subscribe", "QoS"],
+    keywords: [
+      "MQTT broker",
+      "message queue",
+      "AMQP",
+      "publish-subscribe",
+      "QoS",
+    ],
   },
   {
     num: "04",
     name: "IoT Platform & Device Management Layer",
     desc: "The platform manages device identity, telemetry ingestion, rules processing, dashboards, and multi-tenant access control. It is the operational core that operators interact with daily.",
     products: [
-      { name: "Magistrala", href: "/products/magistrala", desc: "Open-source IoT platform with RBAC, dashboards, rules engine" },
+      {
+        name: "Magistrala",
+        href: "/products/magistrala",
+        desc: "Open-source IoT platform with RBAC, dashboards, rules engine",
+      },
     ],
-    keywords: ["device management", "telemetry", "dashboards", "rules engine", "multi-tenancy"],
+    keywords: [
+      "device management",
+      "telemetry",
+      "dashboards",
+      "rules engine",
+      "multi-tenancy",
+    ],
   },
   {
     num: "05",
     name: "Identity & Authorization Layer",
     desc: "Every device, user, and service must be authenticated and authorized before accessing resources. Runtime policy evaluation prevents stale-permission windows that occur when permissions are embedded in tokens.",
     products: [
-      { name: "Atom", href: "/products/atom", desc: "Open-source IAM with runtime RBAC/ABAC for IoT" },
+      {
+        name: "Atom",
+        href: "/products/atom",
+        desc: "Open-source IAM with runtime RBAC/ABAC for IoT",
+      },
     ],
-    keywords: ["device identity", "IAM", "RBAC", "ABAC", "JWT", "authorization"],
+    keywords: [
+      "device identity",
+      "IAM",
+      "RBAC",
+      "ABAC",
+      "JWT",
+      "authorization",
+    ],
   },
   {
     num: "06",
     name: "Edge Compute & Orchestration Layer",
     desc: "WebAssembly workloads can be deployed and updated remotely on both cloud nodes and microcontrollers. This layer enables AI inference, data transformation, and protocol bridging at the edge without firmware reflashing.",
     products: [
-      { name: "Propeller", href: "/products/propeller", desc: "WebAssembly edge orchestrator, cloud-to-MCU" },
+      {
+        name: "Propeller",
+        href: "/products/propeller",
+        desc: "WebAssembly edge orchestrator, cloud-to-MCU",
+      },
     ],
-    keywords: ["WebAssembly", "edge AI", "FaaS", "OTA updates", "Wasm orchestration"],
+    keywords: [
+      "WebAssembly",
+      "edge AI",
+      "FaaS",
+      "OTA updates",
+      "Wasm orchestration",
+    ],
   },
   {
     num: "07",
     name: "Security & Cryptography Layer",
     desc: "Long-lived IoT devices must remain secure after classical PKI is broken by quantum computers. Hardware-accelerated post-quantum cryptography provides forward-secure device identity that outlives the deployment lifetime.",
     products: [
-      { name: "Quarc", href: "/products/quarc", desc: "Post-quantum secure element, ML-KEM & ML-DSA" },
+      {
+        name: "Quarc",
+        href: "/products/quarc",
+        desc: "Post-quantum secure element, ML-KEM & ML-DSA",
+      },
     ],
-    keywords: ["post-quantum cryptography", "secure element", "hardware root of trust", "ML-KEM", "ML-DSA"],
+    keywords: [
+      "post-quantum cryptography",
+      "secure element",
+      "hardware root of trust",
+      "ML-KEM",
+      "ML-DSA",
+    ],
   },
 ];
 
@@ -198,13 +269,15 @@ const faqSchema = JSON.stringify({
     <section class="section" style="border-bottom:1px solid var(--line-3);">
       <div class="container-wide">
         <div class="pillar-definition-block">
-          <h2 class="pillar-definition-h2">What is IIoT platform architecture?</h2>
+          <h2 class="pillar-definition-h2">
+            What is IIoT platform architecture?
+          </h2>
           <p class="pillar-definition-text">
             IIoT platform architecture describes how industrial IoT systems are
-            structured across multiple layers: physical devices and sensors, edge
-            gateways for local processing, a message broker for telemetry
-            transport, a central IoT platform for device management and dashboards,
-            and identity and security layers. Each layer has defined
+            structured across multiple layers: physical devices and sensors,
+            edge gateways for local processing, a message broker for telemetry
+            transport, a central IoT platform for device management and
+            dashboards, and identity and security layers. Each layer has defined
             responsibilities, protocols, and scaling characteristics.
           </p>
         </div>
@@ -284,8 +357,8 @@ const faqSchema = JSON.stringify({
           <div class="pillar-stack-row">
             <div class="pillar-stack-label">Applications & Dashboards</div>
             <div class="pillar-stack-product">
-              <a href="/products/magistrala">Magistrala</a> — visual dashboards,
-              alarm management, reports, rules engine
+              <a href="/products/magistrala">Magistrala</a> — visual dashboards, alarm
+              management, reports, rules engine
             </div>
           </div>
           <div class="pillar-stack-row">
@@ -326,15 +399,15 @@ const faqSchema = JSON.stringify({
           <div class="pillar-stack-row">
             <div class="pillar-stack-label">Edge Gateway (RTOS / MCU)</div>
             <div class="pillar-stack-product">
-              <a href="/products/a0">A0 Gateway</a> — ESP32-C6 RISC-V, Zephyr, 6
-              radios (Wi-Fi 6, BLE, NB-IoT, M-Bus, Thread, Ethernet)
+              <a href="/products/a0">A0 Gateway</a> — ESP32-C6 RISC-V, Zephyr, 6 radios
+              (Wi-Fi 6, BLE, NB-IoT, M-Bus, Thread, Ethernet)
             </div>
           </div>
           <div class="pillar-stack-row">
             <div class="pillar-stack-label">Hardware Security</div>
             <div class="pillar-stack-product">
-              <a href="/products/quarc">Quarc</a> — post-quantum secure element,
-              ML-KEM-768, ML-DSA-65, hardware root of trust
+              <a href="/products/quarc">Quarc</a> — post-quantum secure element, ML-KEM-768,
+              ML-DSA-65, hardware root of trust
             </div>
           </div>
         </div>
@@ -386,7 +459,9 @@ const faqSchema = JSON.stringify({
         <div class="section-head">
           <div class="left">
             <span class="kicker">Design decisions</span>
-            <h2 class="h-2" style="margin-top:14px;">Edge vs cloud processing.</h2>
+            <h2 class="h-2" style="margin-top:14px;">
+              Edge vs cloud processing.
+            </h2>
           </div>
           <p class="lede">
             The decision of where to process data has significant implications
@@ -398,8 +473,8 @@ const faqSchema = JSON.stringify({
             <h3 class="pillar-edge-title">Process at the edge when:</h3>
             <ul class="pillar-edge-list">
               <li>
-                Control loops require sub-100ms response times (cloud round-trips
-                introduce too much latency)
+                Control loops require sub-100ms response times (cloud
+                round-trips introduce too much latency)
               </li>
               <li>
                 Devices operate in locations with intermittent connectivity —
@@ -410,8 +485,8 @@ const faqSchema = JSON.stringify({
                 relevant to the cloud (bandwidth reduction)
               </li>
               <li>
-                Data sovereignty or regulatory requirements restrict transmission
-                of raw device data off-premises
+                Data sovereignty or regulatory requirements restrict
+                transmission of raw device data off-premises
               </li>
               <li>
                 AI inference must run close to the sensor to be actionable (e.g.
@@ -423,20 +498,20 @@ const faqSchema = JSON.stringify({
             <h3 class="pillar-edge-title">Process in the cloud when:</h3>
             <ul class="pillar-edge-list">
               <li>
-                Long-term storage and historical analysis are the primary use case
-                — cloud storage is cheaper and more scalable
+                Long-term storage and historical analysis are the primary use
+                case — cloud storage is cheaper and more scalable
               </li>
               <li>
-                Cross-site correlation is needed — aggregating data from hundreds
-                of sites for fleet-level analytics
+                Cross-site correlation is needed — aggregating data from
+                hundreds of sites for fleet-level analytics
               </li>
               <li>
-                Heavy ML training runs that require GPU resources not available at
-                the edge
+                Heavy ML training runs that require GPU resources not available
+                at the edge
               </li>
               <li>
-                Compliance reporting and audit trails that must be tamper-proof and
-                centrally managed
+                Compliance reporting and audit trails that must be tamper-proof
+                and centrally managed
               </li>
               <li>
                 Real-time dashboards and alerting that operators access from
@@ -470,8 +545,8 @@ const faqSchema = JSON.stringify({
             <p class="pillar-security-desc">
               Every device needs a unique cryptographic identity issued at
               manufacture or provisioning. Device certificates or API keys
-              authenticate the device to the message broker and platform. When
-              a device is decommissioned, its credentials must be revoked and
+              authenticate the device to the message broker and platform. When a
+              device is decommissioned, its credentials must be revoked and
               access blocked immediately — runtime policy evaluation (not
               token-embedded permissions) guarantees this.
             </p>
@@ -494,15 +569,11 @@ const faqSchema = JSON.stringify({
             <h3 class="pillar-security-name">Secure boot & OTA updates</h3>
             <p class="pillar-security-desc">
               Firmware must be signed and the signature verified at boot before
-              execution. OTA updates must be delivered over authenticated, encrypted
-              channels and must include rollback protection — a failed update
-              must not brick the device or leave it in an unknown state.
+              execution. OTA updates must be delivered over authenticated,
+              encrypted channels and must include rollback protection — a failed
+              update must not brick the device or leave it in an unknown state.
             </p>
-            <a
-              href="/products/quarc"
-              class="btn-link"
-              style="font-size:13px;"
-            >
+            <a href="/products/quarc" class="btn-link" style="font-size:13px;">
               Quarc — hardware-enforced secure boot →
             </a>
           </div>
@@ -516,11 +587,7 @@ const faqSchema = JSON.stringify({
               (signatures) for device identity and firmware signing, especially
               for devices with 10+ year deployment lifetimes.
             </p>
-            <a
-              href="/products/quarc"
-              class="btn-link"
-              style="font-size:13px;"
-            >
+            <a href="/products/quarc" class="btn-link" style="font-size:13px;">
               Quarc — PQC secure element →
             </a>
           </div>

--- a/src/pages/mosquitto-alternative.astro
+++ b/src/pages/mosquitto-alternative.astro
@@ -120,9 +120,10 @@ const faqSchema = JSON.stringify({
             The enterprise Mosquitto alternative for production IoT.
           </h1>
           <p class="lede" style="margin-top:20px; max-width:52ch;">
-            Eclipse Mosquitto is excellent for development and small deployments. When
-            you need clustering, durable message delivery, AMQP support, and
-            100K+ connections, FluxMQ takes over where Mosquitto stops.
+            Eclipse Mosquitto is excellent for development and small
+            deployments. When you need clustering, durable message delivery,
+            AMQP support, and 100K+ connections, FluxMQ takes over where
+            Mosquitto stops.
           </p>
           <div class="btn-row" style="margin-top:32px;">
             <a href="/products/fluxmq" class="btn btn-primary">
@@ -150,8 +151,8 @@ const faqSchema = JSON.stringify({
             Mosquitto is a single-node MQTT broker. It has no built-in
             clustering, no durable queues, and no AMQP support. Teams that need
             high availability, horizontal scaling beyond a single node, or
-            guaranteed message delivery to consumer groups typically migrate to a
-            distributed broker like FluxMQ.
+            guaranteed message delivery to consumer groups typically migrate to
+            a distributed broker like FluxMQ.
           </p>
         </div>
       </div>
@@ -284,7 +285,8 @@ const faqSchema = JSON.stringify({
                     <td class="alt-col-fluxmq alt-yes">{fluxmq}</td>
                     <td
                       class={
-                        mosquitto === "No" || mosquitto === "N/A (no clustering)"
+                        mosquitto === "No" ||
+                        mosquitto === "N/A (no clustering)"
                           ? "alt-no"
                           : mosquitto === "Yes"
                             ? "alt-yes"
@@ -304,8 +306,8 @@ const faqSchema = JSON.stringify({
         >
           Sources: Eclipse Mosquitto documentation (mosquitto.org), FluxMQ
           source code and documentation (github.com/absmach/fluxmq). Mosquitto
-          plugin ecosystem can extend some features; table reflects out-of-the-box
-          capabilities.
+          plugin ecosystem can extend some features; table reflects
+          out-of-the-box capabilities.
         </p>
       </div>
     </section>
@@ -370,18 +372,17 @@ const faqSchema = JSON.stringify({
             <div class="num">01</div>
             <h4>Run FluxMQ alongside Mosquitto</h4>
             <p>
-              Start FluxMQ on the same network. Point a test client at FluxMQ
-              on port 1883. Both brokers can run simultaneously during
-              migration.
+              Start FluxMQ on the same network. Point a test client at FluxMQ on
+              port 1883. Both brokers can run simultaneously during migration.
             </p>
           </div>
           <div class="step">
             <div class="num">02</div>
             <h4>Validate client compatibility</h4>
             <p>
-              Connect your existing MQTT clients to FluxMQ. QoS levels,
-              retained messages, Last Will and Testament, and shared
-              subscriptions all work as expected.
+              Connect your existing MQTT clients to FluxMQ. QoS levels, retained
+              messages, Last Will and Testament, and shared subscriptions all
+              work as expected.
             </p>
           </div>
           <div class="step">
@@ -394,8 +395,7 @@ const faqSchema = JSON.stringify({
           </div>
         </div>
         <div style="margin-top:40px;">
-          <a href="/products/fluxmq" class="btn btn-primary"
-            >Explore FluxMQ →</a
+          <a href="/products/fluxmq" class="btn btn-primary">Explore FluxMQ →</a
           >
         </div>
       </div>
@@ -425,8 +425,8 @@ const faqSchema = JSON.stringify({
           Ready to scale beyond Mosquitto?
         </h2>
         <p class="lede" style="margin:20px auto 36px;">
-          FluxMQ is open source, Apache 2.0, and ships as a single Go binary.
-          No external dependencies. Full clustering from day one.
+          FluxMQ is open source, Apache 2.0, and ships as a single Go binary. No
+          external dependencies. Full clustering from day one.
         </p>
         <div class="btn-row" style="justify-content:center;">
           <a

--- a/src/pages/mosquitto-alternative.astro
+++ b/src/pages/mosquitto-alternative.astro
@@ -1,0 +1,636 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import FAQAccordion from "../components/FAQAccordion.astro";
+
+const comparisonRows = [
+  {
+    feature: "MQTT 3.1.1 & 5.0",
+    fluxmq: "Yes",
+    mosquitto: "Yes",
+  },
+  {
+    feature: "AMQP 0.9.1",
+    fluxmq: "Yes",
+    mosquitto: "No",
+  },
+  {
+    feature: "AMQP 1.0",
+    fluxmq: "Yes",
+    mosquitto: "No",
+  },
+  {
+    feature: "CoAP bridge",
+    fluxmq: "Yes",
+    mosquitto: "No",
+  },
+  {
+    feature: "Built-in horizontal clustering",
+    fluxmq: "Yes (embedded etcd)",
+    mosquitto: "No",
+  },
+  {
+    feature: "Durable message queues",
+    fluxmq: "Yes (consumer groups, DLQ)",
+    mosquitto: "No",
+  },
+  {
+    feature: "Kafka-style retention",
+    fluxmq: "Yes",
+    mosquitto: "No",
+  },
+  {
+    feature: "Raft-based replication",
+    fluxmq: "Yes",
+    mosquitto: "No",
+  },
+  {
+    feature: "Per-IP & per-client rate limiting",
+    fluxmq: "Yes",
+    mosquitto: "Plugin required",
+  },
+  {
+    feature: "mTLS inter-broker gRPC",
+    fluxmq: "Yes",
+    mosquitto: "N/A (no clustering)",
+  },
+  {
+    feature: "Zero external dependencies",
+    fluxmq: "Yes (single Go binary)",
+    mosquitto: "Yes (single C binary)",
+  },
+  {
+    feature: "License",
+    fluxmq: "Apache 2.0",
+    mosquitto: "EPL 2.0 / EDL 1.0",
+  },
+];
+
+const faqs = [
+  {
+    q: "Why do teams outgrow Mosquitto?",
+    a: "Mosquitto is a single-node broker. When deployments need high availability, horizontal scaling, or durable message delivery guarantees, Mosquitto cannot be extended without external orchestration. FluxMQ ships clustering, Raft replication, and durable queues out of the box.",
+  },
+  {
+    q: "Is FluxMQ a drop-in replacement for Mosquitto?",
+    a: "Yes for clients. Any MQTT 3.1.1 or 5.0 client that works with Mosquitto connects to FluxMQ without code changes — the wire protocol is identical. The operational difference is that FluxMQ is configured differently and adds AMQP, durable queues, and clustering on top.",
+  },
+  {
+    q: "Does FluxMQ support the same MQTT feature set as Mosquitto?",
+    a: "FluxMQ supports all standard MQTT 3.1.1 and 5.0 features including QoS 0/1/2, retained messages, Last Will and Testament, shared subscriptions, flow control, and user properties. MQTT 5.0 feature coverage is complete.",
+  },
+  {
+    q: "Can I run FluxMQ as a single node like Mosquitto?",
+    a: "Yes. FluxMQ runs as a single node with the same single-binary operational model as Mosquitto. Clustering is opt-in — add cluster peers in the YAML config when you are ready to scale.",
+  },
+  {
+    q: "What is the license difference?",
+    a: "Mosquitto is dual-licensed under the Eclipse Public License 2.0 and Eclipse Distribution License 1.0. FluxMQ is Apache 2.0. Both are open source. Apache 2.0 is generally considered more permissive for commercial use and integration into proprietary systems.",
+  },
+  {
+    q: "How does FluxMQ handle 500K+ concurrent connections?",
+    a: "FluxMQ uses zero-copy packet parsing, object pooling, and efficient trie-based topic matching to sustain high connection counts. Session ownership is tracked per broker node with sub-100ms session takeover when a node fails.",
+  },
+];
+
+const faqSchema = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map(({ q, a }) => ({
+    "@type": "Question",
+    name: q,
+    acceptedAnswer: { "@type": "Answer", text: a },
+  })),
+});
+---
+
+<BaseLayout
+  title="Mosquitto Alternative — FluxMQ Enterprise MQTT Broker"
+  description="Looking for a Mosquitto alternative with clustering, durable queues, and AMQP? FluxMQ is an open-source MQTT 5.0 broker designed for enterprise IoT — 500K+ connections, no external dependencies, Apache 2.0."
+>
+  <Header />
+  <main>
+    <!-- Hero -->
+    <section class="page-hero">
+      <div class="container-wide">
+        <div class="hero-copy" style="max-width:700px;">
+          <span class="kicker">Mosquitto Alternative</span>
+          <h1 class="h-1" style="margin-top:14px; max-width:18ch;">
+            The enterprise Mosquitto alternative for production IoT.
+          </h1>
+          <p class="lede" style="margin-top:20px; max-width:52ch;">
+            Eclipse Mosquitto is excellent for development and small deployments. When
+            you need clustering, durable message delivery, AMQP support, and
+            100K+ connections, FluxMQ takes over where Mosquitto stops.
+          </p>
+          <div class="btn-row" style="margin-top:32px;">
+            <a href="/products/fluxmq" class="btn btn-primary">
+              FluxMQ Product Page →
+            </a>
+            <a
+              href="https://github.com/absmach/fluxmq"
+              class="btn"
+              target="_blank"
+              rel="noopener">GitHub ↗</a
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Featured snippet — definition block -->
+    <section class="section" style="border-bottom:1px solid var(--line-3);">
+      <div class="container-wide">
+        <div class="alt-definition-block">
+          <h2 class="alt-definition-h2">
+            When does Mosquitto need an alternative?
+          </h2>
+          <p class="alt-definition-text">
+            Mosquitto is a single-node MQTT broker. It has no built-in
+            clustering, no durable queues, and no AMQP support. Teams that need
+            high availability, horizontal scaling beyond a single node, or
+            guaranteed message delivery to consumer groups typically migrate to a
+            distributed broker like FluxMQ.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- What Mosquitto is good at -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Context</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              What Mosquitto is good at.
+            </h2>
+          </div>
+          <p class="lede">
+            Mosquitto is a mature, lightweight MQTT broker maintained by the
+            Eclipse Foundation. It's the right tool for many use cases.
+          </p>
+        </div>
+        <div class="alt-pros-grid">
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Development & testing</div>
+            <p class="alt-pro-desc">
+              Fast to spin up, minimal config, runs everywhere. The standard
+              choice for local development and integration testing.
+            </p>
+          </div>
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Constrained devices</div>
+            <p class="alt-pro-desc">
+              The <code>mosquitto</code> C binary is lean enough to run on embedded
+              Linux systems with very limited resources.
+            </p>
+          </div>
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Small deployments</div>
+            <p class="alt-pro-desc">
+              For a single-site installation with a few hundred devices and no
+              HA requirement, Mosquitto is simple and reliable.
+            </p>
+          </div>
+          <div class="alt-pro-card">
+            <div class="alt-pro-title">Broad client compatibility</div>
+            <p class="alt-pro-desc">
+              Every MQTT client library on the planet has been tested against
+              Mosquitto. It is the reference implementation.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- When you need more -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Limitations</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              Where Mosquitto hits its ceiling.
+            </h2>
+          </div>
+        </div>
+        <div class="alt-limit-grid">
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">No built-in clustering</div>
+            <p class="alt-limit-desc">
+              Mosquitto is a single-node broker. High-availability setups
+              require external tooling — load balancers, shared state stores, or
+              broker bridges — none of which Mosquitto manages itself.
+            </p>
+          </div>
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">No durable queues</div>
+            <p class="alt-limit-desc">
+              Mosquitto has QoS 1/2 and retained messages but no durable queue
+              semantics — consumer groups, offset tracking, dead-letter queues,
+              or Kafka-style retention with replay.
+            </p>
+          </div>
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">MQTT only</div>
+            <p class="alt-limit-desc">
+              Mosquitto speaks MQTT. If your architecture also has AMQP services
+              (RabbitMQ consumers, SAP integrations, Azure Service Bus
+              connectors), you need a separate broker for that traffic.
+            </p>
+          </div>
+          <div class="alt-limit-item">
+            <div class="alt-limit-title">Limited at scale</div>
+            <p class="alt-limit-desc">
+              Mosquitto handles hundreds of thousands of connections on capable
+              hardware but cannot distribute that load across multiple nodes
+              natively. FluxMQ scales linearly by adding nodes.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Comparison</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              FluxMQ vs Mosquitto — feature by feature.
+            </h2>
+          </div>
+        </div>
+        <div class="alt-table-wrap">
+          <table class="alt-table">
+            <thead>
+              <tr>
+                <th>Feature</th>
+                <th class="alt-col-fluxmq">FluxMQ</th>
+                <th>Mosquitto</th>
+              </tr>
+            </thead>
+            <tbody>
+              {
+                comparisonRows.map(({ feature, fluxmq, mosquitto }) => (
+                  <tr>
+                    <td>{feature}</td>
+                    <td class="alt-col-fluxmq alt-yes">{fluxmq}</td>
+                    <td
+                      class={
+                        mosquitto === "No" || mosquitto === "N/A (no clustering)"
+                          ? "alt-no"
+                          : mosquitto === "Yes"
+                            ? "alt-yes"
+                            : "alt-partial"
+                      }
+                    >
+                      {mosquitto}
+                    </td>
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
+        </div>
+        <p
+          style="font-size:12px; color:var(--ink-4); margin-top:12px; line-height:1.6;"
+        >
+          Sources: Eclipse Mosquitto documentation (mosquitto.org), FluxMQ
+          source code and documentation (github.com/absmach/fluxmq). Mosquitto
+          plugin ecosystem can extend some features; table reflects out-of-the-box
+          capabilities.
+        </p>
+      </div>
+    </section>
+
+    <!-- FluxMQ for enterprise -->
+    <section
+      style="background:var(--surface-accent); color:var(--on-accent); padding:80px 0;"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker" style="color:var(--on-accent-muted);"
+              >FluxMQ</span
+            >
+            <h2 class="h-1" style="margin-top:14px; color:var(--on-accent);">
+              Built for what Mosquitto doesn't cover.
+            </h2>
+          </div>
+          <p class="lede" style="color:var(--on-accent-dim); max-width:36ch;">
+            Same MQTT wire protocol. Full clustering, durable queues, and AMQP
+            support added. Apache 2.0 for all features.
+          </p>
+        </div>
+        <div class="alt-highlights-grid">
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">500K+</div>
+            <div class="alt-highlight-l">Concurrent connections per node</div>
+          </div>
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">300K+</div>
+            <div class="alt-highlight-l">Messages/sec per node</div>
+          </div>
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">&lt;10ms</div>
+            <div class="alt-highlight-l">Local latency</div>
+          </div>
+          <div class="alt-highlight">
+            <div class="alt-highlight-v">Apache 2.0</div>
+            <div class="alt-highlight-l">All features, no enterprise tier</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Migration path -->
+    <section class="section">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Migration</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              Moving from Mosquitto to FluxMQ.
+            </h2>
+          </div>
+          <p class="lede">
+            Client code does not change. Any MQTT 3.1.1 or 5.0 client that
+            connects to Mosquitto connects to FluxMQ without modification.
+          </p>
+        </div>
+        <div class="steps">
+          <div class="step">
+            <div class="num">01</div>
+            <h4>Run FluxMQ alongside Mosquitto</h4>
+            <p>
+              Start FluxMQ on the same network. Point a test client at FluxMQ
+              on port 1883. Both brokers can run simultaneously during
+              migration.
+            </p>
+          </div>
+          <div class="step">
+            <div class="num">02</div>
+            <h4>Validate client compatibility</h4>
+            <p>
+              Connect your existing MQTT clients to FluxMQ. QoS levels,
+              retained messages, Last Will and Testament, and shared
+              subscriptions all work as expected.
+            </p>
+          </div>
+          <div class="step">
+            <div class="num">03</div>
+            <h4>Cut over and enable clustering</h4>
+            <p>
+              Redirect clients to FluxMQ. When ready for HA, add cluster nodes
+              in the YAML config. etcd handles coordination automatically.
+            </p>
+          </div>
+        </div>
+        <div style="margin-top:40px;">
+          <a href="/products/fluxmq" class="btn btn-primary"
+            >Explore FluxMQ →</a
+          >
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section
+      class="section"
+      style="background:var(--paper-2); border-top:1px solid var(--line-3); border-bottom:1px solid var(--line-3);"
+    >
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">FAQ</span>
+            <h2 class="h-2" style="margin-top:14px;">Common questions.</h2>
+          </div>
+        </div>
+        <FAQAccordion items={faqs} />
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="section">
+      <div class="container-narrow" style="text-align:center;">
+        <span class="kicker">Get started</span>
+        <h2 class="h-2" style="margin-top:14px;">
+          Ready to scale beyond Mosquitto?
+        </h2>
+        <p class="lede" style="margin:20px auto 36px;">
+          FluxMQ is open source, Apache 2.0, and ships as a single Go binary.
+          No external dependencies. Full clustering from day one.
+        </p>
+        <div class="btn-row" style="justify-content:center;">
+          <a
+            href="https://github.com/absmach/fluxmq"
+            class="btn btn-primary"
+            target="_blank"
+            rel="noopener">View on GitHub ↗</a
+          >
+          <a
+            href="https://www.absmach.eu/docs/fluxmq"
+            class="btn"
+            target="_blank"
+            rel="noopener">Documentation ↗</a
+          >
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <script is:inline type="application/ld+json" set:html={faqSchema} />
+  <script type="application/ld+json" is:inline>
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.absmach.eu/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Mosquitto Alternative",
+          "item": "https://www.absmach.eu/mosquitto-alternative"
+        }
+      ]
+    }
+  </script>
+</BaseLayout>
+
+<style>
+  .alt-definition-block {
+    background: var(--paper-2);
+    border: 1px solid var(--line-3);
+    border-left: 4px solid var(--ink);
+    border-radius: var(--radius-lg);
+    padding: 32px 40px;
+    max-width: 820px;
+  }
+  .alt-definition-h2 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 14px;
+  }
+  .alt-definition-text {
+    font-size: 16px;
+    line-height: 1.7;
+    color: var(--ink-2);
+    margin: 0;
+  }
+
+  .alt-pros-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-top: 48px;
+  }
+  .alt-pro-card {
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    background: var(--paper-2);
+  }
+  .alt-pro-title {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ink);
+    margin-bottom: 8px;
+  }
+  .alt-pro-desc {
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  .alt-limit-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    margin-top: 48px;
+  }
+  .alt-limit-item {
+    border-left: 3px solid var(--line-2);
+    padding-left: 20px;
+  }
+  .alt-limit-title {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ink);
+    margin-bottom: 8px;
+  }
+  .alt-limit-desc {
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  .alt-table-wrap {
+    overflow-x: auto;
+    margin-top: 48px;
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+  }
+  .alt-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .alt-table th {
+    padding: 14px 20px;
+    text-align: left;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-3);
+    border-bottom: 1px solid var(--line-3);
+    background: var(--paper-2);
+  }
+  .alt-table td {
+    padding: 13px 20px;
+    border-bottom: 1px solid var(--line-3);
+    color: var(--ink-2);
+    font-size: 13px;
+  }
+  .alt-table tr:last-child td {
+    border-bottom: none;
+  }
+  .alt-table td:first-child {
+    color: var(--ink);
+    font-weight: 500;
+  }
+  .alt-col-fluxmq {
+    background: rgba(7, 55, 99, 0.03);
+  }
+  .alt-yes {
+    color: var(--ink) !important;
+    font-weight: 600 !important;
+  }
+  .alt-no {
+    color: var(--ink-3) !important;
+  }
+  .alt-partial {
+    color: var(--ink-2) !important;
+  }
+
+  .alt-highlights-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    margin-top: 48px;
+  }
+  .alt-highlight {
+    background: rgba(255, 255, 255, 0.04);
+    padding: 32px 24px;
+    text-align: center;
+  }
+  .alt-highlight-v {
+    font-family: "Montserrat", sans-serif;
+    font-weight: 700;
+    font-size: 28px;
+    color: var(--on-accent);
+    margin-bottom: 8px;
+  }
+  .alt-highlight-l {
+    font-size: 13px;
+    color: var(--on-accent-dim);
+    line-height: 1.4;
+  }
+
+  @media (max-width: 980px) {
+    .alt-highlights-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (max-width: 640px) {
+    .alt-pros-grid,
+    .alt-limit-grid {
+      grid-template-columns: 1fr;
+    }
+    .alt-highlights-grid {
+      grid-template-columns: 1fr;
+    }
+    .alt-definition-block {
+      padding: 24px;
+    }
+  }
+</style>

--- a/src/pages/products/a0.astro
+++ b/src/pages/products/a0.astro
@@ -172,7 +172,7 @@ const faqSchema = JSON.stringify({
 ---
 
 <BaseLayout
-  title="A0 — Open-Source IoT Module | Wi-Fi 6, BLE 5, NB-IoT, Wireless M-Bus, RISC-V"
+  title="A0 — Open-Source IoT Module | Wi-Fi 6, BLE, NB-IoT, RISC-V"
   description="Open-source IoT module with 6 native radios — Wi-Fi 6, BLE 5, IEEE 802.15.4, Wireless M-Bus, NB-IoT/LTE-M, and Ethernet. ESP32-C6 RISC-V, Zephyr RTOS, Wasm-ready. EU-manufactured."
 >
   <Header />

--- a/src/pages/products/a1.astro
+++ b/src/pages/products/a1.astro
@@ -139,8 +139,8 @@ const faqSchema = JSON.stringify({
 ---
 
 <BaseLayout
-  title="A1 — RISC-V Linux IoT Gateway | Industrial-Grade | Container & Wasm-Ready"
-  description="RISC-V Linux gateway for industrial IoT with container and Wasm workload support. Full Linux OS, edge AI, and industrial-grade reliability."
+  title="A1 — RISC-V Linux Gateway | EU-Manufactured, Wasm-Ready"
+  description="RISC-V Linux gateway for industrial IoT. EU-manufactured, container and Wasm workload support, full Linux OS, edge AI, and industrial-grade reliability."
 >
   <Header />
   <main>
@@ -168,7 +168,7 @@ const faqSchema = JSON.stringify({
               ></span>
               A1 · Industrial Gateway · Hardware
             </div>
-            <h1 class="tagline">A1 – Linux Gateway for Industrial IoT.</h1>
+            <h1 class="tagline">RISC-V Linux IoT Gateway — Industrial-Grade, Wasm-Ready.</h1>
             <p class="lede" style="margin-top:16px; max-width:48ch;">
               A1 is a powerful Linux-based IoT gateway built on RISC-V
               architecture. It offers robust connectivity, advanced processing
@@ -430,7 +430,10 @@ const faqSchema = JSON.stringify({
         </h2>
         <p class="lede" style="margin:20px auto 36px;">
           Read the documentation, explore the open hardware, or talk to the team
-          about your deployment requirements.
+          about your deployment requirements. Use <a
+            href="/products/propeller"
+            style="color:inherit; text-decoration:underline;">Propeller</a
+          > to deploy and update Wasm workloads on A1 without reflashing firmware.
         </p>
         <div class="btn-row" style="justify-content:center;">
           <a

--- a/src/pages/products/a1.astro
+++ b/src/pages/products/a1.astro
@@ -168,7 +168,9 @@ const faqSchema = JSON.stringify({
               ></span>
               A1 · Industrial Gateway · Hardware
             </div>
-            <h1 class="tagline">RISC-V Linux IoT Gateway — Industrial-Grade, Wasm-Ready.</h1>
+            <h1 class="tagline">
+              RISC-V Linux IoT Gateway — Industrial-Grade, Wasm-Ready.
+            </h1>
             <p class="lede" style="margin-top:16px; max-width:48ch;">
               A1 is a powerful Linux-based IoT gateway built on RISC-V
               architecture. It offers robust connectivity, advanced processing

--- a/src/pages/products/atom.astro
+++ b/src/pages/products/atom.astro
@@ -796,7 +796,10 @@ const faqSchema = JSON.stringify({
           Atom is the identity and authorization layer powering the <a
             href="/products/magistrala"
             style="color:inherit; text-decoration:underline;">Magistrala</a
-          > IoT platform. Deploy it standalone or as part of the full IoT stack —
+          > IoT platform. It integrates natively with <a
+            href="/products/fluxmq"
+            style="color:inherit; text-decoration:underline;">FluxMQ</a
+          > for message-level authorization. Deploy it standalone or as part of the full IoT stack —
           single binary, Apache 2.0, PostgreSQL-backed.
         </p>
         <div class="btn-row" style="justify-content:center;">

--- a/src/pages/products/atom.astro
+++ b/src/pages/products/atom.astro
@@ -799,8 +799,8 @@ const faqSchema = JSON.stringify({
           > IoT platform. It integrates natively with <a
             href="/products/fluxmq"
             style="color:inherit; text-decoration:underline;">FluxMQ</a
-          > for message-level authorization. Deploy it standalone or as part of the full IoT stack —
-          single binary, Apache 2.0, PostgreSQL-backed.
+          > for message-level authorization. Deploy it standalone or as part of the
+          full IoT stack — single binary, Apache 2.0, PostgreSQL-backed.
         </p>
         <div class="btn-row" style="justify-content:center;">
           <a href="/contact" class="btn btn-primary">Contact Us →</a>

--- a/src/pages/products/fluxmq.astro
+++ b/src/pages/products/fluxmq.astro
@@ -608,7 +608,9 @@ graph TD
         <div class="section-head">
           <div class="left">
             <span class="kicker">Compare</span>
-            <h2 class="h-2" style="margin-top:14px;">See how FluxMQ stacks up.</h2>
+            <h2 class="h-2" style="margin-top:14px;">
+              See how FluxMQ stacks up.
+            </h2>
           </div>
         </div>
         <div style="display:flex; gap:16px; flex-wrap:wrap;">
@@ -617,14 +619,22 @@ graph TD
             style="flex:1; min-width:240px; padding:24px; border:1px solid var(--line-3); border-radius:var(--radius); text-decoration:none; color:var(--ink); background:var(--paper-2);"
           >
             <div style="font-weight:600; font-size:15px;">FluxMQ vs EMQX →</div>
-            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">Apache 2.0 open-source vs commercial BSL licensing — feature comparison and migration guide.</div>
+            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">
+              Apache 2.0 open-source vs commercial BSL licensing — feature
+              comparison and migration guide.
+            </div>
           </a>
           <a
             href="/mosquitto-alternative"
             style="flex:1; min-width:240px; padding:24px; border:1px solid var(--line-3); border-radius:var(--radius); text-decoration:none; color:var(--ink); background:var(--paper-2);"
           >
-            <div style="font-weight:600; font-size:15px;">FluxMQ vs Mosquitto →</div>
-            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">When to move beyond a single-node broker to a distributed, production-grade alternative.</div>
+            <div style="font-weight:600; font-size:15px;">
+              FluxMQ vs Mosquitto →
+            </div>
+            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">
+              When to move beyond a single-node broker to a distributed,
+              production-grade alternative.
+            </div>
           </a>
         </div>
       </div>
@@ -645,8 +655,8 @@ graph TD
           > IoT platform deployments. Pair it with <a
             href="/products/atom"
             style="color:inherit; text-decoration:underline;">Atom</a
-          > for device identity and runtime authorization. Download the binary, read the documentation,
-          or explore the source on GitHub.
+          > for device identity and runtime authorization. Download the binary, read
+          the documentation, or explore the source on GitHub.
         </p>
         <p style="margin:0 auto 36px; font-size:14px; color:var(--ink-3);">
           Evaluating brokers? See our detailed comparisons: <a
@@ -654,7 +664,8 @@ graph TD
             style="color:inherit; text-decoration:underline;">FluxMQ vs EMQX</a
           > and <a
             href="/mosquitto-alternative"
-            style="color:inherit; text-decoration:underline;">FluxMQ vs Mosquitto</a
+            style="color:inherit; text-decoration:underline;"
+            >FluxMQ vs Mosquitto</a
           >.
         </p>
         <div class="btn-row" style="justify-content:center;">

--- a/src/pages/products/fluxmq.astro
+++ b/src/pages/products/fluxmq.astro
@@ -223,12 +223,17 @@ const faqSchema = JSON.stringify({
               style="margin-top:32px; justify-content:center;"
             >
               <a
-                href="https://www.absmach.eu/docs/fluxmq"
+                href="https://github.com/absmach/fluxmq"
                 class="btn btn-primary"
+                target="_blank"
+                rel="noopener">GitHub ↗</a
+              >
+              <a
+                href="https://www.absmach.eu/docs/fluxmq"
+                class="btn"
                 target="_blank"
                 rel="noopener">Documentation ↗</a
               >
-              <a href="/contact" class="btn">Contact Us →</a>
             </div>
           </div>
         </div>
@@ -597,6 +602,34 @@ graph TD
       </div>
     </section>
 
+    <!-- Compare -->
+    <section class="section" style="border-top:1px solid var(--line-3);">
+      <div class="container-wide">
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Compare</span>
+            <h2 class="h-2" style="margin-top:14px;">See how FluxMQ stacks up.</h2>
+          </div>
+        </div>
+        <div style="display:flex; gap:16px; flex-wrap:wrap;">
+          <a
+            href="/emqx-alternative"
+            style="flex:1; min-width:240px; padding:24px; border:1px solid var(--line-3); border-radius:var(--radius); text-decoration:none; color:var(--ink); background:var(--paper-2);"
+          >
+            <div style="font-weight:600; font-size:15px;">FluxMQ vs EMQX →</div>
+            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">Apache 2.0 open-source vs commercial BSL licensing — feature comparison and migration guide.</div>
+          </a>
+          <a
+            href="/mosquitto-alternative"
+            style="flex:1; min-width:240px; padding:24px; border:1px solid var(--line-3); border-radius:var(--radius); text-decoration:none; color:var(--ink); background:var(--paper-2);"
+          >
+            <div style="font-weight:600; font-size:15px;">FluxMQ vs Mosquitto →</div>
+            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">When to move beyond a single-node broker to a distributed, production-grade alternative.</div>
+          </a>
+        </div>
+      </div>
+    </section>
+
     <!-- CTA -->
     <section
       class="section"
@@ -605,12 +638,24 @@ graph TD
       <div class="container-narrow" style="text-align:center;">
         <span class="kicker">Get started</span>
         <h2 class="h-2" style="margin-top:14px;">Drop in FluxMQ today.</h2>
-        <p class="lede" style="margin:20px auto 36px;">
+        <p class="lede" style="margin:20px auto 24px;">
           FluxMQ is the recommended message broker for <a
             href="/products/magistrala"
             style="color:inherit; text-decoration:underline;">Magistrala</a
-          > IoT platform deployments. Download the binary, read the documentation,
+          > IoT platform deployments. Pair it with <a
+            href="/products/atom"
+            style="color:inherit; text-decoration:underline;">Atom</a
+          > for device identity and runtime authorization. Download the binary, read the documentation,
           or explore the source on GitHub.
+        </p>
+        <p style="margin:0 auto 36px; font-size:14px; color:var(--ink-3);">
+          Evaluating brokers? See our detailed comparisons: <a
+            href="/emqx-alternative"
+            style="color:inherit; text-decoration:underline;">FluxMQ vs EMQX</a
+          > and <a
+            href="/mosquitto-alternative"
+            style="color:inherit; text-decoration:underline;">FluxMQ vs Mosquitto</a
+          >.
         </p>
         <div class="btn-row" style="justify-content:center;">
           <a

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -848,6 +848,22 @@ const faqSchema = JSON.stringify({
       </div>
     </section>
 
+    <!-- Architecture guide -->
+    <section class="section" style="border-top:1px solid var(--line-3);">
+      <div class="container-wide">
+        <div style="display:flex; gap:16px; flex-wrap:wrap;">
+          <a
+            href="/iiot-platform-architecture"
+            style="flex:1; min-width:260px; padding:24px; border:1px solid var(--line-3); border-radius:var(--radius); text-decoration:none; color:var(--ink); background:var(--paper-2);"
+          >
+            <div style="font-size:11px; font-family:'JetBrains Mono',monospace; font-weight:600; text-transform:uppercase; letter-spacing:0.1em; color:var(--ink-4); margin-bottom:10px;">Guide</div>
+            <div style="font-weight:600; font-size:15px;">IIoT Platform Architecture Explained →</div>
+            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">How Magistrala fits into a seven-layer industrial IoT stack: protocols, edge compute, identity, and security.</div>
+          </a>
+        </div>
+      </div>
+    </section>
+
     <!-- CTA -->
     <section class="section">
       <div class="container-narrow" style="text-align:center;">
@@ -855,9 +871,15 @@ const faqSchema = JSON.stringify({
         <h2 class="h-2" style="margin-top:14px;">
           Ready to connect your devices?
         </h2>
-        <p class="lede" style="margin:20px auto 36px;">
+        <p class="lede" style="margin:20px auto 24px;">
           Start with the free tier, self-host the open-source platform, or talk
           to us about enterprise deployments.
+        </p>
+        <p style="margin:0 auto 36px; font-size:14px; color:var(--ink-3);">
+          Planning your IIoT stack? Read our <a
+            href="/iiot-platform-architecture"
+            style="color:inherit; text-decoration:underline;">IIoT platform architecture guide</a
+          >.
         </p>
         <div class="btn-row" style="justify-content:center;">
           <a

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -856,9 +856,18 @@ const faqSchema = JSON.stringify({
             href="/iiot-platform-architecture"
             style="flex:1; min-width:260px; padding:24px; border:1px solid var(--line-3); border-radius:var(--radius); text-decoration:none; color:var(--ink); background:var(--paper-2);"
           >
-            <div style="font-size:11px; font-family:'JetBrains Mono',monospace; font-weight:600; text-transform:uppercase; letter-spacing:0.1em; color:var(--ink-4); margin-bottom:10px;">Guide</div>
-            <div style="font-weight:600; font-size:15px;">IIoT Platform Architecture Explained →</div>
-            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">How Magistrala fits into a seven-layer industrial IoT stack: protocols, edge compute, identity, and security.</div>
+            <div
+              style="font-size:11px; font-family:'JetBrains Mono',monospace; font-weight:600; text-transform:uppercase; letter-spacing:0.1em; color:var(--ink-4); margin-bottom:10px;"
+            >
+              Guide
+            </div>
+            <div style="font-weight:600; font-size:15px;">
+              IIoT Platform Architecture Explained →
+            </div>
+            <div style="font-size:13px; color:var(--ink-3); margin-top:6px;">
+              How Magistrala fits into a seven-layer industrial IoT stack:
+              protocols, edge compute, identity, and security.
+            </div>
           </a>
         </div>
       </div>
@@ -878,7 +887,8 @@ const faqSchema = JSON.stringify({
         <p style="margin:0 auto 36px; font-size:14px; color:var(--ink-3);">
           Planning your IIoT stack? Read our <a
             href="/iiot-platform-architecture"
-            style="color:inherit; text-decoration:underline;">IIoT platform architecture guide</a
+            style="color:inherit; text-decoration:underline;"
+            >IIoT platform architecture guide</a
           >.
         </p>
         <div class="btn-row" style="justify-content:center;">

--- a/src/pages/products/propeller.astro
+++ b/src/pages/products/propeller.astro
@@ -226,7 +226,9 @@ const faqSchema = JSON.stringify({
               class="prod-logo-img"
               style="height:56px; margin-bottom:8px; filter:invert(1);"
             />
-            <h1 class="tagline">Open-Source Wasm Edge Orchestrator for the Cloud-Edge Continuum.</h1>
+            <h1 class="tagline">
+              Open-Source Wasm Edge Orchestrator for the Cloud-Edge Continuum.
+            </h1>
             <p class="lede" style="margin-top:16px; max-width:48ch;">
               Deploy portable Wasm workloads across the full cloud-edge
               continuum — from Kubernetes clusters to Zephyr RTOS

--- a/src/pages/products/propeller.astro
+++ b/src/pages/products/propeller.astro
@@ -196,7 +196,7 @@ const faqSchema = JSON.stringify({
 ---
 
 <BaseLayout
-  title="Propeller — Open-Source WebAssembly Orchestrator for Cloud-to-Edge"
+  title="Propeller — Open-Source WebAssembly Edge Orchestrator"
   description="Open-source WebAssembly orchestrator for the cloud-edge continuum. Deploy Wasm workloads from Kubernetes clusters to Zephyr RTOS microcontrollers — sub-10ms boot times, OCI registry support, MQTT via Magistrala, and FaaS at the edge."
 >
   <Header />
@@ -226,7 +226,7 @@ const faqSchema = JSON.stringify({
               class="prod-logo-img"
               style="height:56px; margin-bottom:8px; filter:invert(1);"
             />
-            <h1 class="tagline">Open-Source WebAssembly Orchestrator.</h1>
+            <h1 class="tagline">Open-Source Wasm Edge Orchestrator for the Cloud-Edge Continuum.</h1>
             <p class="lede" style="margin-top:16px; max-width:48ch;">
               Deploy portable Wasm workloads across the full cloud-edge
               continuum — from Kubernetes clusters to Zephyr RTOS

--- a/src/pages/products/quarc.astro
+++ b/src/pages/products/quarc.astro
@@ -251,8 +251,8 @@ const faqSchema = JSON.stringify({
 ---
 
 <BaseLayout
-  title="Open-Source Post-Quantum Secure Element — Abstract Machines"
-  description="Quarc is an open-source post-quantum secure element with hardware-accelerated ML-KEM and ML-DSA, built for IoT, industrial systems, confidential computing, and long-lived device trust."
+  title="Quarc — Post-Quantum Secure Element for IoT | Open-Source"
+  description="Quarc is an open-source post-quantum cryptography secure element with hardware-accelerated ML-KEM-768 and ML-DSA-65, built for IoT, industrial systems, confidential computing, and long-lived device trust."
 >
   <Header />
   <main>


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is an SEO improvement because it adds new content pages targeting
high-intent search queries, optimises existing product pages for organic
search, and fixes internal linking gaps that left new pages orphaned.

## What does this do?

**New pages**
- `/emqx-alternative` — comparison landing page targeting "emqx alternative"
- `/mosquitto-alternative` — comparison landing page targeting "mosquitto alternative"
- `/iiot-platform-architecture` — pillar page targeting "iiot architecture explained"

All three pages include FAQPage JSON-LD schema, BreadcrumbList JSON-LD schema,
and featured snippet definition blocks for PAA (People Also Ask) capture.

**Product page improvements** (magistrala, fluxmq, atom, propeller, a0, a1, quarc)
- H1s rewritten for primary keyword targeting
- Title tags shortened to ≤60 characters across all pages
- CTAs and cross-links between related products added

**Internal linking**
- `fluxmq.astro` links to both comparison pages contextually in the CTA section
- `magistrala.astro` links to the IIoT architecture guide in the CTA section
- Footer `Resources` column gains a `Guides` subsection linking all three new pages

**Hero H1 consistency**
- New pages updated from `class="tagline"` to `class="h-1"` with
  `margin-top:14px; max-width:18ch` to match the `solutions/index.astro` pattern

## Which issue(s) does this PR fix/relate to?

N/A

## Have you included tests for your changes?

No automated tests. Build verified clean with `pnpm run build`. All three
new pages confirmed present in `dist/` output.

## Did you document any new/modified features?

### Notes
