### PR TITLE
Add tiered managed pricing to Magistrala product page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
   devToolbar: { enabled: false },
 
   redirects: {
+    "/pricing": "/magistrala/pricing/",
     "/products/s0": "/products/a0",
     "/products/s1": "/products/a1",
   },

--- a/src/components/FAQAccordion.astro
+++ b/src/components/FAQAccordion.astro
@@ -4,6 +4,7 @@ interface Props {
     q: string;
     a: string;
     points?: string[];
+    bullets?: { label: string; text: string }[];
     link?: { href: string; label: string };
   }[];
 }
@@ -12,7 +13,7 @@ const { items } = Astro.props;
 
 <div class="faq-list">
   {
-    items.map(({ q, a, points, link }) => (
+    items.map(({ q, a, points, bullets, link }) => (
       <details class="faq-item">
         <summary class="faq-q">{q}</summary>
         <p class="faq-a">{a}</p>
@@ -22,6 +23,15 @@ const { items } = Astro.props;
               <li>{point}</li>
             ))}
           </ol>
+        )}
+        {bullets && bullets.length > 0 && (
+          <ul class="faq-a-bullets">
+            {bullets.map((b) => (
+              <li>
+                <strong>{b.label}</strong> — {b.text}
+              </li>
+            ))}
+          </ul>
         )}
         {link && (
           <a class="faq-a-link" href={link.href}>
@@ -51,6 +61,28 @@ const { items } = Astro.props;
   }
   .faq-a-list li:last-child {
     margin-bottom: 0;
+  }
+  .faq-item:has(.faq-a-bullets) .faq-a {
+    padding-bottom: 10px;
+  }
+  .faq-a-bullets {
+    margin: 0;
+    padding: 0 24px 20px 40px;
+    color: var(--ink-2);
+    font-size: 14px;
+    line-height: 1.65;
+    list-style: disc;
+  }
+  .faq-a-bullets li {
+    margin-bottom: 8px;
+    padding-left: 4px;
+  }
+  .faq-a-bullets li:last-child {
+    margin-bottom: 0;
+  }
+  .faq-a-bullets strong {
+    color: var(--ink);
+    font-weight: 600;
   }
   .faq-a-link {
     display: inline-block;

--- a/src/components/FAQAccordion.astro
+++ b/src/components/FAQAccordion.astro
@@ -1,17 +1,45 @@
 ---
 interface Props {
-  items: { q: string; a: string }[];
+  items: { q: string; a: string; points?: string[] }[];
 }
 const { items } = Astro.props;
 ---
 
 <div class="faq-list">
   {
-    items.map(({ q, a }) => (
+    items.map(({ q, a, points }) => (
       <details class="faq-item">
         <summary class="faq-q">{q}</summary>
         <p class="faq-a">{a}</p>
+        {points && points.length > 0 && (
+          <ol class="faq-a-list">
+            {points.map((point) => (
+              <li>{point}</li>
+            ))}
+          </ol>
+        )}
       </details>
     ))
   }
 </div>
+
+<style>
+  .faq-item:has(.faq-a-list) .faq-a {
+    padding-bottom: 10px;
+  }
+  .faq-a-list {
+    margin: 0;
+    padding: 0 24px 20px 44px;
+    color: var(--ink-2);
+    font-size: 14px;
+    line-height: 1.65;
+    list-style: decimal;
+  }
+  .faq-a-list li {
+    margin-bottom: 8px;
+    padding-left: 4px;
+  }
+  .faq-a-list li:last-child {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/components/FAQAccordion.astro
+++ b/src/components/FAQAccordion.astro
@@ -1,13 +1,18 @@
 ---
 interface Props {
-  items: { q: string; a: string; points?: string[] }[];
+  items: {
+    q: string;
+    a: string;
+    points?: string[];
+    link?: { href: string; label: string };
+  }[];
 }
 const { items } = Astro.props;
 ---
 
 <div class="faq-list">
   {
-    items.map(({ q, a, points }) => (
+    items.map(({ q, a, points, link }) => (
       <details class="faq-item">
         <summary class="faq-q">{q}</summary>
         <p class="faq-a">{a}</p>
@@ -17,6 +22,11 @@ const { items } = Astro.props;
               <li>{point}</li>
             ))}
           </ol>
+        )}
+        {link && (
+          <a class="faq-a-link" href={link.href}>
+            {link.label} →
+          </a>
         )}
       </details>
     ))
@@ -41,5 +51,21 @@ const { items } = Astro.props;
   }
   .faq-a-list li:last-child {
     margin-bottom: 0;
+  }
+  .faq-a-link {
+    display: inline-block;
+    margin: 0 24px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s ease;
+  }
+  .faq-a-link:hover {
+    border-bottom-color: var(--accent);
+  }
+  .faq-item:has(.faq-a-link) .faq-a {
+    padding-bottom: 10px;
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -398,11 +398,11 @@ const plainLinks = [
         GitHub ↗
       </a>
       <a
-        href="/contact"
+        href="/pricing"
         class="btn btn-primary"
         style="padding:8px 14px; font-size:13px;"
       >
-        Contact us
+        Pricing
       </a>
       <button
         class="nav-hamburger"
@@ -542,7 +542,7 @@ const plainLinks = [
         target="_blank"
         rel="noopener noreferrer">GitHub ↗</a
       >
-      <a href="/contact" class="btn btn-primary">Contact us</a>
+      <a href="/pricing" class="btn btn-primary">Pricing</a>
     </div>
   </div>
 </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -398,7 +398,7 @@ const plainLinks = [
         GitHub ↗
       </a>
       <a
-        href="/pricing"
+        href="/magistrala/pricing/"
         class="btn btn-primary"
         style="padding:8px 14px; font-size:13px;"
       >
@@ -542,7 +542,7 @@ const plainLinks = [
         target="_blank"
         rel="noopener noreferrer">GitHub ↗</a
       >
-      <a href="/pricing" class="btn btn-primary">Pricing</a>
+      <a href="/magistrala/pricing/" class="btn btn-primary">Pricing</a>
     </div>
   </div>
 </div>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -97,7 +97,8 @@ const communityFeatures = [
   "Unlimited clients, channels, groups, tenants, messages",
   "Every update, free forever",
   "Full control of your data and infrastructure",
-  "Open source under Apache 2.0 — no lock-in",
+  "Open-source backend under Apache 2.0",
+  "Free-to-use UI, deployed as a Docker container",
   "Community support",
 ];
 
@@ -119,7 +120,7 @@ const pricingFaqs = [
     bullets: [
       {
         label: "Community",
-        text: "the free, open-source edition (Apache 2.0) you run yourself — the backend services plus a free, open-source version of the UI.",
+        text: "free to run yourself — open-source backend services (Apache 2.0) plus a free-to-use UI you deploy as a Docker container.",
       },
       {
         label: "Private Cloud",
@@ -179,7 +180,7 @@ const pricingFaqs = [
   },
   {
     q: "Is self-hosting free?",
-    a: "Partly. Magistrala core is open source under the Apache 2.0 license and free to self-host forever, as is the Community Edition. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — requires a self-managed license or a managed plan.",
+    a: "Partly. The Magistrala backend is open source under the Apache 2.0 license and free to self-host forever, and the Community Edition UI is free to use and deploy as a Docker container. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — requires a self-managed license or a managed plan.",
   },
 ];
 ---
@@ -244,11 +245,11 @@ const pricingFaqs = [
           <span class="label">Community Edition · Free</span>
           <h3 class="mg-ce-title">Free — and it always will be.</h3>
           <p class="mg-ce-desc">
-            The Community Edition is the open-source core of Magistrala, released
-            under Apache 2.0. Run the full multi-tenant IoT platform on your own
-            hardware, keep complete control of your data and deployment, and
-            build without license fees, seat limits, or vendor lock-in. It's
-            yours to run, extend, and own.
+            Community Edition is free to run yourself. The backend services are
+            open source under Apache 2.0; the UI is free to use and deploy as a
+            Docker container. Run the full multi-tenant IoT platform on your own
+            hardware, keep complete control of your data, and build without
+            license fees, seat limits, or vendor lock-in.
           </p>
           <ul class="mg-ce-feats">
             {communityFeatures.map((f) => <li>→ {f}</li>)}

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,5 +1,5 @@
 ---
-import { Boxes, Cloud, Server, Users } from "@lucide/astro";
+import { Boxes, Check, Cloud, Server, Users } from "@lucide/astro";
 import FAQAccordion from "./FAQAccordion.astro";
 
 interface Props {
@@ -117,6 +117,104 @@ const eeFeatures = [
   "Priority security patches & updates",
 ];
 
+// ── Community vs Enterprise Edition comparison ─────────────────────
+// Enterprise Edition ships at two service levels, mirrored by the
+// Business and Enterprise plans. Cell values: true → included,
+// false → not included, string → the specific value for that column.
+const compareGroups = [
+  {
+    group: "Platform",
+    rows: [
+      { f: "Open-source backend (Apache 2.0)", ce: true, biz: true, ent: true },
+      {
+        f: "Multi-protocol messaging (MQTT, CoAP, HTTP, WebSocket)",
+        ce: true,
+        biz: true,
+        ent: true,
+      },
+      {
+        f: "Multi-tenancy & fine-grained access control",
+        ce: true,
+        biz: true,
+        ent: true,
+      },
+      {
+        f: "Unlimited clients, channels, groups & messages",
+        ce: true,
+        biz: true,
+        ent: true,
+      },
+    ],
+  },
+  {
+    group: "Interface & data",
+    rows: [
+      {
+        f: "User interface",
+        ce: "Free community UI",
+        biz: "Commercial + whitelabel",
+        ent: "Commercial + whitelabel",
+      },
+      { f: "Dashboards", ce: false, biz: true, ent: true },
+      { f: "Audit logs", ce: false, biz: true, ent: true },
+    ],
+  },
+  {
+    group: "Enterprise features",
+    rows: [
+      {
+        f: "Rules Engine & custom message formats",
+        ce: false,
+        biz: true,
+        ent: true,
+      },
+      { f: "Alarms", ce: false, biz: true, ent: true },
+      { f: "Reports", ce: false, biz: true, ent: true },
+    ],
+  },
+  {
+    group: "Operations & support",
+    rows: [
+      {
+        f: "Security patches & updates",
+        ce: "Community",
+        biz: "Priority",
+        ent: "Priority",
+      },
+      {
+        f: "Support",
+        ce: "Community",
+        biz: "Priority",
+        ent: "Highest priority",
+      },
+      {
+        f: "Dedicated support hours",
+        ce: false,
+        biz: "2h / month",
+        ent: "12h / month",
+      },
+      {
+        f: "Backups",
+        ce: false,
+        biz: "Weekly · 3-month retention",
+        ent: "Daily · 3-month retention",
+      },
+      {
+        f: "Dedicated instance",
+        ce: "Self-hosted",
+        biz: true,
+        ent: true,
+      },
+      {
+        f: "Uptime SLA & high-availability clustering",
+        ce: false,
+        biz: false,
+        ent: false,
+      },
+    ],
+  },
+];
+
 const pricingFaqs = [
   {
     q: "What's the difference between Community, Private Cloud, and Self-managed?",
@@ -176,11 +274,11 @@ const pricingFaqs = [
   },
   {
     q: "Can I deploy on my own cloud or on-premises?",
-    a: "Yes. With a self-managed license you run Magistrala Enterprise yourself, anywhere. With the “Self-managed” option we deploy and operate it on your infrastructure — AWS, GCP, Azure, or on-premises, including air-gapped environments — aligned to your SLA, security, and data-residency policies.",
+    a: "Yes. With a self-managed license you run Magistrala Enterprise yourself, anywhere. With the “Managed by us” option we deploy and operate it on your infrastructure — AWS, GCP, Azure, or on-premises, including air-gapped environments — aligned to your SLA, security, and data-residency policies.",
   },
   {
     q: "Do you offer a custom SLA and high availability?",
-    a: "Yes. Private Cloud Enterprise and Custom plans, and self-managed “Self-managed” deployments, support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the plan and are tailored to your requirements.",
+    a: "A formal uptime SLA and high-availability clustering are part of the Custom plan and the self-managed “Managed by us” option only. The standard Private Cloud tiers (Prototype, Business, Enterprise) each run as a single dedicated instance with proactive monitoring and support, but without a contractual SLA or clustering. If you need a guaranteed uptime target or active-active high availability, that's what the Custom plan is for — response times and architecture are tailored to your requirements.",
   },
   {
     q: "Is self-hosting free?",
@@ -472,6 +570,83 @@ const pricingFaqs = [
           </a>
         </div>
       </div>
+    </div>
+
+    <!-- ── Emphasis: no artificial gates ───────────────────────── -->
+    <div class="mg-emphasis">
+      <span class="mg-emphasis-kicker">No artificial gates</span>
+      <h3 class="mg-emphasis-title">Features, not fences.</h3>
+      <p>
+        We don't meter you with arbitrary caps — no “10 devices”, no “400
+        messages”, no “3 dashboards”. You either have a feature or you don't.
+        Once you're licensed, the only limits are soft ones, set by your
+        hardware and configuration — never by us. And every deployment, Private
+        Cloud or self-managed, is a full, dedicated instance. Never shared.
+      </p>
+    </div>
+
+    <!-- ── Compare editions ────────────────────────────────────── -->
+    <div class="mg-compare">
+      <div class="mg-compare-head">
+        <span class="kicker">Editions</span>
+        <h3 class="h-3" style="margin-top:12px;">
+          Community vs Enterprise Edition.
+        </h3>
+        <p class="mg-compare-sub">
+          Enterprise Edition powers both the managed Private Cloud plans and
+          self-managed licenses, at two service levels — Business and
+          Enterprise.
+        </p>
+      </div>
+      <div class="mg-compare-scroll">
+        <table class="mg-compare-table">
+          <thead>
+            <tr>
+              <th scope="col">Feature</th>
+              <th scope="col">Community</th>
+              <th scope="col">EE · Business</th>
+              <th scope="col">EE · Enterprise</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              compareGroups.map((grp) => (
+                <Fragment>
+                  <tr class="mg-compare-group">
+                    <th scope="colgroup" colspan="4">
+                      {grp.group}
+                    </th>
+                  </tr>
+                  {grp.rows.map((row) => (
+                    <tr>
+                      <th scope="row">{row.f}</th>
+                      {[row.ce, row.biz, row.ent].map((c) => (
+                        <td>
+                          {typeof c === "boolean" ? (
+                            c ? (
+                              <span class="mg-yes">
+                                <Check size={16} />
+                              </span>
+                            ) : (
+                              <span class="mg-no">—</span>
+                            )
+                          ) : (
+                            <span class="mg-val">{c}</span>
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </Fragment>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+      <p class="mg-compare-foot">
+        A formal uptime SLA and high-availability clustering are available on the
+        Custom plan (and self-managed “Managed by us”) only.
+      </p>
     </div>
 
     <!-- ── Shared pricing FAQ ──────────────────────────────────── -->
@@ -826,5 +1001,126 @@ const pricingFaqs = [
   }
   .mg-price-faq-head .kicker {
     display: block;
+  }
+
+  /* ── Emphasis band ────────────────────────────────────────── */
+  .mg-emphasis {
+    max-width: 900px;
+    margin: 8px auto 0;
+    padding: 44px 48px;
+    text-align: center;
+    background: var(--surface-accent);
+    color: var(--on-accent);
+    border-radius: var(--radius-lg);
+  }
+  .mg-emphasis-kicker {
+    font-family: var(--font-mono), monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--accent-2);
+  }
+  .mg-emphasis-title {
+    margin: 10px 0 0;
+    font-size: 26px;
+    font-weight: 600;
+    color: var(--on-accent);
+  }
+  .mg-emphasis p {
+    margin: 14px auto 0;
+    max-width: 64ch;
+    font-size: 15px;
+    line-height: 1.65;
+    color: var(--on-accent-dim);
+  }
+  @media (max-width: 600px) {
+    .mg-emphasis {
+      padding: 32px 24px;
+    }
+  }
+
+  /* ── Compare editions table ───────────────────────────────── */
+  .mg-compare {
+    max-width: 960px;
+    margin: 72px auto 0;
+  }
+  .mg-compare-head {
+    text-align: center;
+    margin-bottom: 32px;
+  }
+  .mg-compare-head .kicker {
+    display: block;
+  }
+  .mg-compare-sub {
+    margin: 12px auto 0;
+    max-width: 60ch;
+    font-size: 15px;
+    color: var(--ink-2);
+  }
+  .mg-compare-scroll {
+    overflow-x: auto;
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius-lg);
+  }
+  .mg-compare-table {
+    width: 100%;
+    min-width: 620px;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .mg-compare-table th,
+  .mg-compare-table td {
+    padding: 12px 16px;
+    text-align: center;
+  }
+  .mg-compare-table thead th {
+    background: var(--paper-2);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink);
+    border-bottom: 1px solid var(--line-3);
+  }
+  .mg-compare-table thead th:first-child,
+  .mg-compare-table tbody th[scope="row"] {
+    text-align: left;
+  }
+  .mg-compare-table thead th:first-child {
+    width: 40%;
+  }
+  .mg-compare-table tbody th[scope="row"] {
+    font-weight: 500;
+    color: var(--ink-2);
+  }
+  .mg-compare-table tbody tr:not(.mg-compare-group) + tr:not(.mg-compare-group),
+  .mg-compare-table tbody tr:not(.mg-compare-group):first-child {
+    border-top: 1px solid var(--line-3);
+  }
+  .mg-compare-group th {
+    text-align: left;
+    background: var(--paper-2);
+    font-family: var(--font-mono), monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-3);
+    padding-top: 16px;
+    padding-bottom: 10px;
+    border-top: 1px solid var(--line-3);
+  }
+  .mg-yes {
+    display: inline-flex;
+    color: var(--accent);
+  }
+  .mg-no {
+    color: var(--ink-4);
+  }
+  .mg-val {
+    color: var(--ink-2);
+  }
+  .mg-compare-foot {
+    margin-top: 16px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--ink-3);
   }
 </style>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -40,7 +40,7 @@ const privateTiers = [
     annual: 5400,
     storage: "180 GB storage for messages",
     transfer: "8 TB data transfer",
-    capacity: "~10k devices · 100M messages / month",
+    capacity: "~5k devices · 10M messages / month",
     inherits: "Prototype",
     featured: true,
     contact: false,
@@ -61,13 +61,13 @@ const privateTiers = [
     annual: 10800,
     storage: "300 GB storage for messages",
     transfer: "8 TB data transfer",
-    capacity: "~100k devices · 1B messages / month",
+    capacity: "~50k devices · 100M messages / month",
     inherits: "Business",
     featured: false,
     contact: false,
     cta: "Get started",
     features: [
-      "Highest-priority support & issue addressing",
+      "Higher-priority support & issue addressing",
       "Dedicated support 12h / month (instead of 2)",
       "Daily backup, 3-month retention (instead of weekly)",
     ],
@@ -142,14 +142,15 @@ const compareGroups = [
       {
         f: "Unlimited clients, channels, groups & messages",
         cells: [true, true, true, true, true],
+        note: true,
       },
     ],
   },
   {
     group: "Capacity",
     rows: [
-      { f: "Devices", cells: [HW, "~200", "~10k", "~100k", "Custom"] },
-      { f: "Messages / month", cells: [HW, "1M", "100M", "1B", "Custom"] },
+      { f: "Devices", cells: [HW, "~200", "~5k", "~50k", "Custom"] },
+      { f: "Messages / month", cells: [HW, "~1M", "~10M", "~100M", "Custom"] },
       {
         f: "Message storage",
         cells: [HW, "80 GB", "180 GB", "300 GB", "Custom"],
@@ -164,14 +165,8 @@ const compareGroups = [
     group: "Interface & data",
     rows: [
       {
-        f: "User interface",
-        cells: [
-          "Free community UI",
-          "Commercial + whitelabel",
-          "Commercial + whitelabel",
-          "Commercial + whitelabel",
-          "Commercial + whitelabel",
-        ],
+        f: "Commercial UI with whitelabeling",
+        cells: [false, true, true, true, true],
       },
       { f: "Dashboards", cells: [false, true, true, true, true] },
       { f: "Audit logs", cells: [false, true, true, true, true] },
@@ -201,8 +196,8 @@ const compareGroups = [
           "Community",
           "Community",
           "Priority",
-          "Highest priority",
-          "Highest priority",
+          "Higher priority",
+          "Higher priority",
         ],
       },
       {
@@ -482,7 +477,7 @@ const pricingFaqs = [
       <p
         style="margin-top:8px; text-align:center; font-size:14px; color:var(--ink-3);"
       >
-        Need more than 100k devices or a bespoke setup?{" "}
+        Need more than 50k devices or a bespoke setup?{" "}
         <a href="/contact" style="color:inherit; text-decoration:underline;"
           >Talk to us</a
         >.
@@ -631,7 +626,10 @@ const pricingFaqs = [
                   </tr>
                   {grp.rows.map((row) => (
                     <tr>
-                      <th scope="row">{row.f}</th>
+                      <th scope="row">
+                        {row.f}
+                        {"note" in row && <span class="mg-ast-sup"> *</span>}
+                      </th>
                       {row.cells.map((c) => (
                         <td>
                           {typeof c === "boolean" ? (
@@ -656,7 +654,8 @@ const pricingFaqs = [
         </table>
       </div>
       <p class="mg-compare-foot">
-        Capacity figures are soft guidance bounded by hardware, not hard caps. A
+        * Limits are purely hardware- and setup-related — we never impose
+        artificial caps. Capacity figures are soft guidance, not hard limits. A
         formal uptime SLA and high-availability clustering are available on the
         Custom plan only.
       </p>
@@ -1129,6 +1128,10 @@ const pricingFaqs = [
   }
   .mg-val {
     color: var(--ink-2);
+  }
+  .mg-ast-sup {
+    color: var(--accent);
+    font-weight: 600;
   }
   .mg-compare-foot {
     margin-top: 16px;

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,4 +1,5 @@
 ---
+import { Boxes, Cloud, Server, Users } from "@lucide/astro";
 import FAQAccordion from "./FAQAccordion.astro";
 
 interface Props {
@@ -6,7 +7,8 @@ interface Props {
 }
 const { showHead = true } = Astro.props;
 
-const pricingTiers = [
+// ── Private Cloud: fully managed, dedicated instances ──────────────
+const privateTiers = [
   {
     name: "Starter",
     goodFor: "Small proofs of concept and testing.",
@@ -100,10 +102,34 @@ const pricingTiers = [
   },
 ];
 
+// ── Community Edition (free, open source) ──────────────────────────
+const communityFeatures = [
+  "Unlimited devices and assets",
+  "Unlimited software updates",
+  "Ability to contribute",
+  "Community support",
+];
+
+// ── Self-managed: run Magistrala Enterprise in your own environment ─
+const eeFeatures = [
+  "Commercial UI with whitelabeling",
+  "Dashboards",
+  "Rules Engine & custom message formats",
+  "Alarms",
+  "Reports",
+  "Audit logs",
+  "Priority security patches & updates",
+  "Enterprise support",
+];
+
 const pricingFaqs = [
   {
-    q: "What's included in a managed plan?",
-    a: "Every managed tier covers hosting, deployment, monitoring, and the updates listed for that tier. Higher tiers add dashboards, audit logs, rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
+    q: "What's the difference between Community, Private Cloud, and Self-managed?",
+    a: "Community Edition is the free, open-source platform you run yourself. Private Cloud is a fully managed, dedicated instance we host and operate for you. Self-managed is Magistrala Enterprise Edition running in your own environment — either licensed to you to operate, or deployed and operated by us on your infrastructure.",
+  },
+  {
+    q: "What's included in a Private Cloud plan?",
+    a: "Every Private Cloud tier covers hosting, deployment, monitoring, and the updates listed for that tier. Higher tiers add dashboards, audit logs, rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
   },
   {
     q: "What counts as a device?",
@@ -111,7 +137,7 @@ const pricingFaqs = [
   },
   {
     q: "Do I get a dedicated instance?",
-    a: "Yes. Every plan runs on a dedicated instance — no shared infrastructure. We provision, run, and manage the instance for you.",
+    a: "Yes. Every Private Cloud plan runs on a dedicated instance — no shared infrastructure. We provision, run, and manage the instance for you.",
   },
   {
     q: "What does “~250 devices · 1M messages / month” actually mean?",
@@ -133,19 +159,23 @@ const pricingFaqs = [
   },
   {
     q: "How does annual billing work?",
-    a: "Annual plans are billed once per year and work out roughly 10% cheaper than paying monthly. You can switch between monthly and annual billing when your term renews.",
+    a: "Annual Private Cloud plans are billed once per year and work out roughly 10% cheaper than paying monthly. You can switch between monthly and annual billing when your term renews.",
+  },
+  {
+    q: "What's the difference between a monthly and a perpetual self-managed license?",
+    a: "A monthly license (€300 per cluster) is billed each month for as long as you use it. A perpetual license (€3,999 per cluster) is a one-time payment that lets you keep running that version indefinitely. Both cover the full Magistrala Enterprise Edition feature set.",
   },
   {
     q: "Can I deploy on my own cloud or on-premises?",
-    a: "Yes, through the Custom plan. We can deploy Magistrala into your AWS, GCP, or Azure account, or fully on-premises, including air-gapped environments, with data residency handled on your infrastructure.",
+    a: "Yes. With a self-managed license you run Magistrala Enterprise yourself, anywhere. With the “Managed by us” option we deploy and operate it on your infrastructure — AWS, GCP, Azure, or on-premises, including air-gapped environments — aligned to your SLA, security, and data-residency policies.",
   },
   {
     q: "Do you offer a custom SLA and high availability?",
-    a: "Enterprise, Dedicated, and Custom plans support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the tier; the Custom plan is tailored to your requirements.",
+    a: "Yes. Private Cloud Enterprise and Custom plans, and self-managed “Managed by us” deployments, support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the plan and are tailored to your requirements.",
   },
   {
     q: "Is self-hosting free?",
-    a: "Partly. Magistrala core is open source under the Apache 2.0 license and free to self-host forever, as is the Magistrala Community Edition. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — is not free to self-host. See the self-hosting options for what each edition includes.",
+    a: "Partly. Magistrala core is open source under the Apache 2.0 license and free to self-host forever, as is the Community Edition. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — requires a self-managed license or a managed plan.",
   },
 ];
 ---
@@ -158,96 +188,267 @@ const pricingFaqs = [
           <div class="left">
             <span class="kicker">Pricing</span>
             <h2 class="h-2" style="margin-top:14px;">
-              Managed Magistrala, priced to scale.
+              Choose how you run Magistrala.
             </h2>
           </div>
           <p class="lede">
-            Fully managed deployments with hosting, updates, and support. Pick
-            the tier that matches your fleet and move up as you grow.
+            Free and open source, fully managed in our private cloud, or
+            self-managed in your own environment — same platform, your choice of
+            operating model.
           </p>
         </div>
       )
     }
 
-    <div class="mg-price-wrap">
-      <div class="mg-price-toggle" role="group" aria-label="Billing period">
-        <button type="button" class="mg-price-opt is-active" data-billing="monthly"
-          >Monthly</button
+    <!-- Tabs -->
+    <div class="mg-tabs-wrap">
+      <div class="mg-tabs" role="tablist" aria-label="Pricing options">
+        <button
+          type="button"
+          class="mg-tab"
+          data-tab="community"
+          role="tab"
+          aria-selected="false"
         >
-        <button type="button" class="mg-price-opt" data-billing="annual"
-          >Annual <span class="mg-save">Save 10%</span></button
+          <Users size={16} /> Community
+        </button>
+        <button
+          type="button"
+          class="mg-tab is-active"
+          data-tab="private"
+          role="tab"
+          aria-selected="true"
         >
+          <Cloud size={16} /> Private Cloud
+        </button>
+        <button
+          type="button"
+          class="mg-tab"
+          data-tab="self"
+          role="tab"
+          aria-selected="false"
+        >
+          <Server size={16} /> Self-managed
+        </button>
       </div>
     </div>
 
-    <div class="mg-pricing-grid">
-      {
-        pricingTiers.map((tier) => (
-          <div
-            class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}${tier.contact ? " is-custom" : ""}`}
-          >
-            {tier.featured && <span class="mg-badge">Popular</span>}
-            <div class="mg-price-head">
-              <div class="label">{tier.name}</div>
-              <div class="mg-price-block">
-                <div class="mg-price">
-                  {tier.contact ? (
-                    <span class="mg-price-contact">Contact</span>
-                  ) : (
-                    <Fragment>
-                      <span
-                        class="mg-amount"
-                        data-monthly={tier.monthly}
-                        data-annual={Math.round((tier.annual ?? 0) / 12)}
-                      >
-                        €{tier.monthly}
-                      </span>
-                      <span class="mg-per">/ month</span>
-                    </Fragment>
-                  )}
-                </div>
-                {!tier.contact && (
-                  <div class="mg-price-note" data-annual-total={tier.annual}>
-                    billed monthly
-                  </div>
-                )}
-              </div>
-              <div class="mg-goodfor">{tier.goodFor}</div>
-            </div>
-            <ul class="mg-price-feats">
-              {tier.inherits && (
-                <li class="mg-inherit">Everything in {tier.inherits}, plus:</li>
-              )}
-              {tier.features.map((feature) => (
-                <li>→ {feature}</li>
-              ))}
-              {tier.capacity && <li class="mg-cap-feat">→ {tier.capacity}</li>}
-              {tier.transfer && <li>→ {tier.transfer}</li>}
-            </ul>
+    <!-- ── Community panel ─────────────────────────────────────── -->
+    <div class="mg-tabpanel" data-panel="community" role="tabpanel" hidden>
+      <div class="mg-ce-card cta-card">
+        <div class="mg-ce-main">
+          <span class="label">Community Edition · Free</span>
+          <h3 class="mg-ce-title">Your free ticket to IoT.</h3>
+          <p class="mg-ce-desc">
+            Get started with Community Edition (CE): a free, open-source (Apache
+            2.0) IoT platform. A powerful, scalable, multi-tenant solution for
+            collecting, processing, visualizing, and managing your IoT data and
+            devices with maximum agility.
+          </p>
+          <ul class="mg-ce-feats">
+            {communityFeatures.map((f) => <li>→ {f}</li>)}
+          </ul>
+          <div class="btn-row" style="margin-top:28px;">
             <a
-              href="/contact"
-              class={`btn${tier.featured ? " btn-primary" : ""}`}
-              style="margin-top:auto; text-align:center; justify-content:center;"
+              href="https://github.com/absmach/magistrala"
+              class="btn btn-primary"
+              target="_blank"
+              rel="noopener">Install ↗</a
             >
-              {tier.cta} →
-            </a>
+            <a
+              href="https://www.absmach.eu/docs/magistrala"
+              class="btn"
+              target="_blank"
+              rel="noopener">Documentation ↗</a
+            >
           </div>
-        ))
-      }
+        </div>
+        <div class="mg-ce-visual" aria-hidden="true">
+          <Boxes size={120} strokeWidth={1} />
+        </div>
+      </div>
     </div>
 
-    <p
-      style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
-    >
-      Prefer to run it yourself? The <a
-        href="/open-source"
-        style="color:inherit; text-decoration:underline;">open-source platform</a
-      > is free forever. Need more than 100k devices?{" "}
-      <a href="/contact" style="color:inherit; text-decoration:underline;"
-        >Talk to us</a
-      >.
-    </p>
+    <!-- ── Private Cloud panel ─────────────────────────────────── -->
+    <div class="mg-tabpanel" data-panel="private" role="tabpanel">
+      <p class="mg-panel-intro">
+        All-inclusive hosting and infrastructure on dedicated instances, so you
+        can focus on building your solutions.
+      </p>
 
+      <div class="mg-price-wrap">
+        <div class="mg-price-toggle" role="group" aria-label="Billing period">
+          <button type="button" class="mg-price-opt is-active" data-billing="monthly"
+            >Monthly</button
+          >
+          <button type="button" class="mg-price-opt" data-billing="annual"
+            >Annual <span class="mg-save">Save 10%</span></button
+          >
+        </div>
+      </div>
+
+      <div class="mg-pricing-grid">
+        {
+          privateTiers.map((tier) => (
+            <div
+              class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}${tier.contact ? " is-custom" : ""}`}
+            >
+              {tier.featured && <span class="mg-badge">Popular</span>}
+              <div class="mg-price-head">
+                <div class="label">{tier.name}</div>
+                <div class="mg-price-block">
+                  <div class="mg-price">
+                    {tier.contact ? (
+                      <span class="mg-price-contact">Contact</span>
+                    ) : (
+                      <Fragment>
+                        <span
+                          class="mg-amount"
+                          data-amt-monthly={tier.monthly}
+                          data-amt-annual={Math.round((tier.annual ?? 0) / 12)}
+                        >
+                          €{tier.monthly}
+                        </span>
+                        <span class="mg-per">/ month</span>
+                      </Fragment>
+                    )}
+                  </div>
+                  {!tier.contact && (
+                    <div
+                      class="mg-price-note"
+                      data-note-monthly="billed monthly"
+                      data-note-annual={`€${(tier.annual ?? 0).toLocaleString()} billed yearly`}
+                    >
+                      billed monthly
+                    </div>
+                  )}
+                </div>
+                <div class="mg-goodfor">{tier.goodFor}</div>
+              </div>
+              <ul class="mg-price-feats">
+                {tier.inherits && (
+                  <li class="mg-inherit">Everything in {tier.inherits}, plus:</li>
+                )}
+                {tier.features.map((feature) => (
+                  <li>→ {feature}</li>
+                ))}
+                {tier.capacity && <li class="mg-cap-feat">→ {tier.capacity}</li>}
+                {tier.transfer && <li>→ {tier.transfer}</li>}
+              </ul>
+              <a
+                href="/contact"
+                class={`btn${tier.featured ? " btn-primary" : ""}`}
+                style="margin-top:auto; text-align:center; justify-content:center;"
+              >
+                {tier.cta} →
+              </a>
+            </div>
+          ))
+        }
+      </div>
+
+      <p
+        style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
+      >
+        Need more than 100k devices or a bespoke setup?{" "}
+        <a href="/contact" style="color:inherit; text-decoration:underline;"
+          >Talk to us</a
+        >.
+      </p>
+    </div>
+
+    <!-- ── Self-managed panel ──────────────────────────────────── -->
+    <div class="mg-tabpanel" data-panel="self" role="tabpanel" hidden>
+      <p class="mg-panel-intro">
+        Run Magistrala Enterprise Edition in your own environment — license it
+        and operate it yourself, or have us deploy and run it for you.
+      </p>
+
+      <div class="mg-price-wrap">
+        <div class="mg-price-toggle" role="group" aria-label="License term">
+          <button type="button" class="mg-price-opt is-active" data-billing="monthly"
+            >Monthly</button
+          >
+          <button type="button" class="mg-price-opt" data-billing="perpetual"
+            >Perpetual</button
+          >
+        </div>
+      </div>
+
+      <div class="mg-self-grid">
+        <div class="cta-card mg-price-card is-featured">
+          <span class="mg-badge">License</span>
+          <div class="mg-price-head">
+            <div class="label">License only</div>
+            <div class="mg-price-block">
+              <div class="mg-price">
+                <span
+                  class="mg-amount"
+                  data-amt-monthly="300"
+                  data-amt-perpetual="3999"
+                >
+                  €300
+                </span>
+              </div>
+              <div
+                class="mg-price-note"
+                data-note-monthly="per cluster · billed monthly"
+                data-note-perpetual="per cluster · one-time license"
+              >
+                per cluster · billed monthly
+              </div>
+            </div>
+            <div class="mg-goodfor">
+              Magistrala Enterprise Edition license for your own deployment. You
+              run and operate it; we license the software, per cluster.
+            </div>
+          </div>
+          <ul class="mg-price-feats">
+            <li class="mg-inherit">Everything in Community Edition, plus:</li>
+            {eeFeatures.map((f) => <li>→ {f}</li>)}
+          </ul>
+          <a
+            href="/contact"
+            class="btn btn-primary"
+            style="margin-top:auto; text-align:center; justify-content:center;"
+          >
+            Get a license →
+          </a>
+        </div>
+
+        <div class="cta-card mg-price-card">
+          <div class="mg-price-head">
+            <div class="label">Managed by us</div>
+            <div class="mg-price-block">
+              <div class="mg-price">
+                <span class="mg-price-contact">Contact</span>
+              </div>
+            </div>
+            <div class="mg-goodfor">
+              We deploy and operate Magistrala Enterprise on your infrastructure,
+              aligned to your SLA, security, and data policies.
+            </div>
+          </div>
+          <ul class="mg-price-feats">
+            <li class="mg-inherit">Everything in License only, plus:</li>
+            <li>→ Deployed on your infrastructure</li>
+            <li>→ Your SLA &amp; uptime targets</li>
+            <li>→ Your security &amp; data-residency policies</li>
+            <li>→ Compliance &amp; certification support</li>
+            <li>→ Operated, monitored &amp; updated by our team</li>
+          </ul>
+          <a
+            href="/contact"
+            class="btn"
+            style="margin-top:auto; text-align:center; justify-content:center;"
+          >
+            Contact us →
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Shared pricing FAQ ──────────────────────────────────── -->
     <div class="mg-price-faq">
       <div class="mg-price-faq-head">
         <span class="kicker">Pricing FAQ</span>
@@ -261,38 +462,146 @@ const pricingFaqs = [
 </section>
 
 <script>
-  const toggle = document.querySelector(".mg-price-toggle");
-  if (toggle) {
+  const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+  // Tab switching
+  const tabs = document.querySelectorAll<HTMLButtonElement>(".mg-tab");
+  const panels = document.querySelectorAll<HTMLElement>(".mg-tabpanel");
+  tabs.forEach((tab) =>
+    tab.addEventListener("click", () => {
+      const name = tab.dataset.tab;
+      tabs.forEach((t) => {
+        const on = t.dataset.tab === name;
+        t.classList.toggle("is-active", on);
+        t.setAttribute("aria-selected", on ? "true" : "false");
+      });
+      panels.forEach((p) => {
+        p.hidden = p.dataset.panel !== name;
+      });
+    }),
+  );
+
+  // Billing / term toggles (scoped to their own panel)
+  document.querySelectorAll<HTMLElement>(".mg-price-toggle").forEach((toggle) => {
     const opts = toggle.querySelectorAll<HTMLButtonElement>(".mg-price-opt");
-    const amounts = document.querySelectorAll<HTMLElement>(".mg-amount");
-    const notes = document.querySelectorAll<HTMLElement>(".mg-price-note");
-
-    const setBilling = (mode: string) => {
-      opts.forEach((o) =>
-        o.classList.toggle("is-active", o.dataset.billing === mode),
-      );
-      amounts.forEach((a) => {
-        const value = mode === "annual" ? a.dataset.annual : a.dataset.monthly;
-        a.textContent = `€${value}`;
-      });
-      notes.forEach((n) => {
-        const total = Number(n.dataset.annualTotal);
-        n.textContent =
-          mode === "annual"
-            ? `€${total.toLocaleString()} billed yearly`
-            : "billed monthly";
-      });
-    };
-
-    opts.forEach((o) =>
-      o.addEventListener("click", () =>
-        setBilling(o.dataset.billing ?? "monthly"),
-      ),
+    const scope: ParentNode = toggle.closest(".mg-tabpanel") ?? document;
+    opts.forEach((opt) =>
+      opt.addEventListener("click", () => {
+        const mode = opt.dataset.billing ?? "monthly";
+        opts.forEach((o) => o.classList.toggle("is-active", o === opt));
+        scope
+          .querySelectorAll<HTMLElement>(".mg-amount")
+          .forEach((a) => {
+            const v = a.dataset[`amt${cap(mode)}`];
+            if (v !== undefined) a.textContent = `€${v}`;
+          });
+        scope
+          .querySelectorAll<HTMLElement>(".mg-price-note")
+          .forEach((n) => {
+            const t = n.dataset[`note${cap(mode)}`];
+            if (t !== undefined) n.textContent = t;
+          });
+      }),
     );
-  }
+  });
 </script>
 
 <style>
+  /* ── Tabs ─────────────────────────────────────────────────── */
+  .mg-tabs-wrap {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 40px;
+  }
+  .mg-tabs {
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4px;
+    padding: 5px;
+    border: 1px solid var(--line-3);
+    border-radius: 999px;
+    background: var(--paper);
+  }
+  .mg-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 18px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--ink-3);
+    font: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+  }
+  .mg-tab.is-active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+  .mg-panel-intro {
+    text-align: center;
+    max-width: 60ch;
+    margin: 0 auto 32px;
+    font-size: 15px;
+    color: var(--ink-2);
+  }
+
+  /* ── Community Edition card ───────────────────────────────── */
+  .mg-ce-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    gap: 32px;
+    align-items: center;
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 48px;
+  }
+  .mg-ce-title {
+    margin: 10px 0 0;
+    font-size: 30px;
+    font-weight: 600;
+    color: var(--ink);
+  }
+  .mg-ce-desc {
+    margin: 14px 0 0;
+    font-size: 15px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    max-width: 60ch;
+  }
+  .mg-ce-feats {
+    list-style: none;
+    padding: 0;
+    margin: 22px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 14px;
+    color: var(--ink-2);
+  }
+  .mg-ce-visual {
+    display: flex;
+    justify-content: center;
+    color: var(--line-2);
+    opacity: 0.5;
+  }
+  @media (max-width: 720px) {
+    .mg-ce-card {
+      grid-template-columns: 1fr;
+      padding: 32px 26px;
+    }
+    .mg-ce-visual {
+      display: none;
+    }
+  }
+
+  /* ── Pricing grid (Private Cloud) ─────────────────────────── */
   .mg-pricing-grid {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
@@ -316,6 +625,21 @@ const pricingFaqs = [
     .mg-goodfor,
     .mg-price-block {
       min-height: 0;
+    }
+  }
+
+  /* ── Self-managed grid ────────────────────────────────────── */
+  .mg-self-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    max-width: 820px;
+    margin: 0 auto;
+    align-items: stretch;
+  }
+  @media (max-width: 640px) {
+    .mg-self-grid {
+      grid-template-columns: 1fr;
     }
   }
 
@@ -368,7 +692,7 @@ const pricingFaqs = [
     color: var(--paper);
   }
 
-  /* ── Tier cards ───────────────────────────────────────────── */
+  /* ── Tier / option cards ──────────────────────────────────── */
   .mg-price-card {
     position: relative;
     padding: 32px 26px;
@@ -451,6 +775,11 @@ const pricingFaqs = [
   .mg-cap-feat {
     font-weight: 600;
     color: var(--ink);
+  }
+
+  /* Self-managed cards have shorter descriptions — relax the min-height */
+  .mg-self-grid .mg-goodfor {
+    min-height: 3.5em;
   }
 
   /* ── Pricing FAQ ──────────────────────────────────────────── */

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -7,12 +7,14 @@ interface Props {
 }
 const { showHead = true } = Astro.props;
 
+const fmt = (n: number) => n.toLocaleString("en-US");
+
 // ── Private Cloud: fully managed, dedicated instances ──────────────
 const privateTiers = [
   {
     name: "Prototype",
     goodFor:
-      "Pilot projects and small deployments with low message bandwidth and non-critical message loss.",
+      "Pilot projects and small deployments with low message bandwidth and best-effort delivery.",
     monthly: 150,
     annual: 1620,
     storage: "80 GB storage for messages",
@@ -269,7 +271,7 @@ const pricingFaqs = [
   },
   {
     q: "Can I change plans later?",
-    a: "Yes, but only up - due to the hardware limitations and guarantees. You can move up between tiers at any time. Going down is possible, but you need to contact us because it requires a migration from our side. Changes are prorated, so you only pay for what you use in a billing period.",
+    a: "Yes. Upgrades are available at any time. Downgrades require a migration on our side, so please contact us to arrange one. Changes are prorated, so you only pay for what you use in a billing period.",
   },
   {
     q: "How does annual billing work?",
@@ -419,10 +421,10 @@ const pricingFaqs = [
                       <Fragment>
                         <span
                           class="mg-amount"
-                          data-amt-monthly={tier.monthly}
-                          data-amt-annual={Math.round((tier.annual ?? 0) / 12)}
+                          data-amt-monthly={fmt(tier.monthly ?? 0)}
+                          data-amt-annual={fmt(Math.round((tier.annual ?? 0) / 12))}
                         >
-                          €{tier.monthly}
+                          €{fmt(tier.monthly ?? 0)}
                         </span>
                         <span class="mg-per">/ month</span>
                       </Fragment>
@@ -432,7 +434,7 @@ const pricingFaqs = [
                     <div
                       class="mg-price-note"
                       data-note-monthly="billed monthly"
-                      data-note-annual={`€${(tier.annual ?? 0).toLocaleString()} billed yearly`}
+                      data-note-annual={`€${fmt(tier.annual ?? 0)} billed yearly`}
                     >
                       billed monthly
                     </div>
@@ -512,7 +514,7 @@ const pricingFaqs = [
                 <span
                   class="mg-amount"
                   data-amt-monthly="300"
-                  data-amt-perpetual="3999"
+                  data-amt-perpetual="3,999"
                 >
                   €300
                 </span>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -277,7 +277,7 @@ const pricingFaqs = [
   },
   {
     q: "What's the difference between a monthly and a perpetual self-managed license?",
-    a: "A monthly license (€300 per cluster) is billed each month for as long as you use it. A perpetual license (€3,999) is a one-time payment that lets you keep running that version indefinitely. Both cover a single cluster deployment of the full Magistrala Enterprise Edition feature set.",
+    a: "Both cover a single-cluster deployment of the full Magistrala Enterprise Edition feature set — the difference is how updates work. A monthly license (€300 per cluster) keeps you on the latest release for as long as you keep paying. A perpetual license (€3,999 per cluster) is a one-time payment that lets you run the version you bought indefinitely, including patches and minor updates for that version — but not upgrades to future major releases.",
   },
   {
     q: "Can I deploy on my own cloud or on-premises?",

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -277,7 +277,7 @@ const pricingFaqs = [
   },
   {
     q: "What's the difference between a monthly and a perpetual self-managed license?",
-    a: "Both cover a single-cluster deployment of the full Magistrala Enterprise Edition feature set — the difference is how updates work. A monthly license (€300 per cluster) keeps you on the latest release for as long as you keep paying. A perpetual license (€3,999 per cluster) is a one-time payment that lets you run the version you bought indefinitely, including patches and minor updates for that version — but not upgrades to future major releases.",
+    a: "Both cover a single-cluster deployment of the full Magistrala Enterprise Edition feature set — the difference is how updates work. A monthly license (€300 per cluster) gives your access to the latest release for as long as your subscription is active. A perpetual license (€3,999 per cluster) is a one-time payment that lets you run the version you bought indefinitely, including patches and minor updates for that version — but not upgrades to future major releases.",
   },
   {
     q: "Can I deploy on my own cloud or on-premises?",

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,0 +1,468 @@
+---
+import FAQAccordion from "./FAQAccordion.astro";
+
+interface Props {
+  showHead?: boolean;
+}
+const { showHead = true } = Astro.props;
+
+const pricingTiers = [
+  {
+    name: "Starter",
+    goodFor: "Small proofs of concept and testing.",
+    monthly: 50,
+    annual: 540,
+    transfer: "3 TB data transfer",
+    capacity: "~50 devices · 100k messages / month",
+    inherits: null,
+    featured: false,
+    contact: false,
+    cta: "Get started",
+    features: [
+      "Commercial UI with whitelabeling",
+      "Basic UI patches",
+      "Security fixes",
+      "Community support",
+    ],
+  },
+  {
+    name: "Prototype",
+    goodFor:
+      "Pilot projects and small deployments with low message bandwidth, where occasional message loss is acceptable.",
+    monthly: 200,
+    annual: 2160,
+    transfer: "5 TB data transfer",
+    capacity: "~250 devices · 1M messages / month",
+    inherits: "Starter",
+    featured: false,
+    contact: false,
+    cta: "Get started",
+    features: ["UI and backend updates", "Dashboards", "Audit logs"],
+  },
+  {
+    name: "Business",
+    goodFor:
+      "Deployments where availability matters and flexibility and features are important. This is where your business starts.",
+    monthly: 500,
+    annual: 5400,
+    transfer: "8 TB data transfer",
+    capacity: "~10k devices · 100M messages / month",
+    inherits: "Prototype",
+    featured: true,
+    contact: false,
+    cta: "Get started",
+    features: [
+      "Rules Engine & custom message format",
+      "Alarms",
+      "Reports",
+      "Priority support & issue addressing",
+      "Dedicated support 2h / month",
+      "Weekly backup, 3-month retention",
+    ],
+  },
+  {
+    name: "Enterprise",
+    goodFor: "Larger deployments where stability and performance matter.",
+    monthly: 1000,
+    annual: 10800,
+    transfer: "8 TB data transfer",
+    capacity: "~100k devices · 1B messages / month",
+    inherits: "Business",
+    featured: false,
+    contact: false,
+    cta: "Get started",
+    features: [
+      "Highest-priority support & issue addressing",
+      "Dedicated support 12h / month (instead of 2)",
+      "Daily backup, 3-month retention (instead of weekly)",
+    ],
+  },
+  {
+    name: "Custom",
+    goodFor:
+      "Large production deployments where HA and SLA matter — huge device and message volumes, no acceptable message loss, and strict data residency and compliance.",
+    monthly: null,
+    annual: null,
+    transfer: null,
+    capacity: null,
+    inherits: null,
+    featured: false,
+    contact: true,
+    cta: "Contact sales",
+    features: [
+      "Deploy on our dedicated cloud, your cloud (AWS, GCP, Azure), or on-premises",
+      "Custom SLA with defined uptime guarantees",
+      "High-availability clustering",
+      "Dedicated infrastructure & data residency",
+      "Custom integrations & message formats",
+      "Priority engineering support",
+    ],
+  },
+];
+
+const pricingFaqs = [
+  {
+    q: "What's included in a managed plan?",
+    a: "Every managed tier covers hosting, deployment, monitoring, and the updates listed for that tier. Higher tiers add dashboards, audit logs, rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
+  },
+  {
+    q: "What counts as a device?",
+    a: "A device is any client that connects to the platform and exchanges messages, regardless of protocol (MQTT, CoAP, HTTP, or WebSocket). The device and message figures on each tier are guidance for typical workloads, not hard quotas.",
+  },
+  {
+    q: "Do I get a dedicated instance?",
+    a: "Yes. Every plan runs on a dedicated instance — no shared infrastructure. We provision, run, and manage the instance for you.",
+  },
+  {
+    q: "What does “~250 devices · 1M messages / month” actually mean?",
+    a: "Because each tier is a dedicated instance, that figure is a rough estimate of how many concurrent devices and messages the instance can comfortably handle. It is not a hard cap — we don't limit you artificially; the only real limit is the hardware and how it's set up. We deliberately avoid a messages-per-second metric, because it's a weak and misleading number for a few reasons:",
+    points: [
+      "Message size varies enormously. A ping is a message, and so is a 100 MB binary upload — they don't cost the same, and they aren't the same priority.",
+      "Networking hiccups and load balancing have an outsized impact as you approach the upper limit of throughput.",
+      "Messages carry different delivery modes and quality-of-service guarantees — not all messages are equally important.",
+      "Throughput also depends on delivery semantics: whether it includes consumer delivery and message persistence. Slow consumers can effectively serialize your infrastructure — and sometimes that's the intended behaviour, especially in low-bandwidth, high-QoS environments.",
+    ],
+  },
+  {
+    q: "What happens if I exceed my device or message limit?",
+    a: "Limits are soft. We monitor usage and reach out to move you to the tier that fits, rather than cutting you off mid-cycle. If a burst is temporary, nothing breaks.",
+  },
+  {
+    q: "Can I change plans later?",
+    a: "Yes, but only up - due to the hardware limitations and guarantees. You can move up between tiers at any time. Going down is possible, but you need to contact us because it requires a migration from our side. Changes are prorated, so you only pay for what you use in a billing period.",
+  },
+  {
+    q: "How does annual billing work?",
+    a: "Annual plans are billed once per year and work out roughly 10% cheaper than paying monthly. You can switch between monthly and annual billing when your term renews.",
+  },
+  {
+    q: "Can I deploy on my own cloud or on-premises?",
+    a: "Yes, through the Custom plan. We can deploy Magistrala into your AWS, GCP, or Azure account, or fully on-premises, including air-gapped environments, with data residency handled on your infrastructure.",
+  },
+  {
+    q: "Do you offer a custom SLA and high availability?",
+    a: "Enterprise, Dedicated, and Custom plans support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the tier; the Custom plan is tailored to your requirements.",
+  },
+  {
+    q: "Is self-hosting free?",
+    a: "Partly. Magistrala core is open source under the Apache 2.0 license and free to self-host forever, as is the Magistrala Community Edition. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — is not free to self-host. See the self-hosting options for what each edition includes.",
+  },
+];
+---
+
+<section class="section" id="pricing">
+  <div class="container-wide">
+    {
+      showHead && (
+        <div class="section-head">
+          <div class="left">
+            <span class="kicker">Pricing</span>
+            <h2 class="h-2" style="margin-top:14px;">
+              Managed Magistrala, priced to scale.
+            </h2>
+          </div>
+          <p class="lede">
+            Fully managed deployments with hosting, updates, and support. Pick
+            the tier that matches your fleet and move up as you grow.
+          </p>
+        </div>
+      )
+    }
+
+    <div class="mg-price-wrap">
+      <div class="mg-price-toggle" role="group" aria-label="Billing period">
+        <button type="button" class="mg-price-opt is-active" data-billing="monthly"
+          >Monthly</button
+        >
+        <button type="button" class="mg-price-opt" data-billing="annual"
+          >Annual <span class="mg-save">Save 10%</span></button
+        >
+      </div>
+    </div>
+
+    <div class="mg-pricing-grid">
+      {
+        pricingTiers.map((tier) => (
+          <div
+            class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}${tier.contact ? " is-custom" : ""}`}
+          >
+            {tier.featured && <span class="mg-badge">Popular</span>}
+            <div class="mg-price-head">
+              <div class="label">{tier.name}</div>
+              <div class="mg-price-block">
+                <div class="mg-price">
+                  {tier.contact ? (
+                    <span class="mg-price-contact">Contact</span>
+                  ) : (
+                    <Fragment>
+                      <span
+                        class="mg-amount"
+                        data-monthly={tier.monthly}
+                        data-annual={Math.round((tier.annual ?? 0) / 12)}
+                      >
+                        €{tier.monthly}
+                      </span>
+                      <span class="mg-per">/ month</span>
+                    </Fragment>
+                  )}
+                </div>
+                {!tier.contact && (
+                  <div class="mg-price-note" data-annual-total={tier.annual}>
+                    billed monthly
+                  </div>
+                )}
+              </div>
+              <div class="mg-goodfor">{tier.goodFor}</div>
+            </div>
+            <ul class="mg-price-feats">
+              {tier.inherits && (
+                <li class="mg-inherit">Everything in {tier.inherits}, plus:</li>
+              )}
+              {tier.features.map((feature) => (
+                <li>→ {feature}</li>
+              ))}
+              {tier.capacity && <li class="mg-cap-feat">→ {tier.capacity}</li>}
+              {tier.transfer && <li>→ {tier.transfer}</li>}
+            </ul>
+            <a
+              href="/contact"
+              class={`btn${tier.featured ? " btn-primary" : ""}`}
+              style="margin-top:auto; text-align:center; justify-content:center;"
+            >
+              {tier.cta} →
+            </a>
+          </div>
+        ))
+      }
+    </div>
+
+    <p
+      style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
+    >
+      Prefer to run it yourself? The <a
+        href="/open-source"
+        style="color:inherit; text-decoration:underline;">open-source platform</a
+      > is free forever. Need more than 100k devices?{" "}
+      <a href="/contact" style="color:inherit; text-decoration:underline;"
+        >Talk to us</a
+      >.
+    </p>
+
+    <div class="mg-price-faq">
+      <div class="mg-price-faq-head">
+        <span class="kicker">Pricing FAQ</span>
+        <h3 class="h-3" style="margin-top:12px;">
+          Questions about plans &amp; billing.
+        </h3>
+      </div>
+      <FAQAccordion items={pricingFaqs} />
+    </div>
+  </div>
+</section>
+
+<script>
+  const toggle = document.querySelector(".mg-price-toggle");
+  if (toggle) {
+    const opts = toggle.querySelectorAll<HTMLButtonElement>(".mg-price-opt");
+    const amounts = document.querySelectorAll<HTMLElement>(".mg-amount");
+    const notes = document.querySelectorAll<HTMLElement>(".mg-price-note");
+
+    const setBilling = (mode: string) => {
+      opts.forEach((o) =>
+        o.classList.toggle("is-active", o.dataset.billing === mode),
+      );
+      amounts.forEach((a) => {
+        const value = mode === "annual" ? a.dataset.annual : a.dataset.monthly;
+        a.textContent = `€${value}`;
+      });
+      notes.forEach((n) => {
+        const total = Number(n.dataset.annualTotal);
+        n.textContent =
+          mode === "annual"
+            ? `€${total.toLocaleString()} billed yearly`
+            : "billed monthly";
+      });
+    };
+
+    opts.forEach((o) =>
+      o.addEventListener("click", () =>
+        setBilling(o.dataset.billing ?? "monthly"),
+      ),
+    );
+  }
+</script>
+
+<style>
+  .mg-pricing-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 16px;
+    align-items: stretch;
+  }
+  @media (max-width: 1200px) {
+    .mg-pricing-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+  @media (max-width: 820px) {
+    .mg-pricing-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (max-width: 560px) {
+    .mg-pricing-grid {
+      grid-template-columns: 1fr;
+    }
+    .mg-goodfor,
+    .mg-price-block {
+      min-height: 0;
+    }
+  }
+
+  /* ── Billing toggle ───────────────────────────────────────── */
+  .mg-price-wrap {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 44px;
+  }
+  .mg-price-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    border: 1px solid var(--line-3);
+    border-radius: 999px;
+    background: var(--paper);
+  }
+  .mg-price-opt {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 18px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--ink-3);
+    font: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+  }
+  .mg-price-opt.is-active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+  .mg-save {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+  .mg-price-opt.is-active .mg-save {
+    background: rgba(246, 244, 238, 0.2);
+    color: var(--paper);
+  }
+
+  /* ── Tier cards ───────────────────────────────────────────── */
+  .mg-price-card {
+    position: relative;
+    padding: 32px 26px;
+    gap: 16px;
+    min-height: 0;
+  }
+  .mg-price-card.is-featured {
+    border-color: var(--ink);
+    box-shadow: var(--shadow-lg);
+  }
+  .mg-price-card.is-custom {
+    background: var(--paper-2);
+  }
+  .mg-badge {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    font-family: var(--font-mono), monospace;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: #fff;
+  }
+  .mg-price-head {
+    display: block;
+  }
+  .mg-price-block {
+    margin-top: 14px;
+    min-height: 62px;
+  }
+  .mg-goodfor {
+    margin-top: 14px;
+    min-height: 130px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--ink-3);
+  }
+  .mg-price {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .mg-amount,
+  .mg-price-contact {
+    font-size: 34px;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1;
+  }
+  .mg-price-contact {
+    font-size: 28px;
+  }
+  .mg-per {
+    font-size: 13px;
+    color: var(--ink-3);
+  }
+  .mg-price-note {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--ink-3);
+    min-height: 16px;
+  }
+  .mg-price-feats {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+  .mg-inherit,
+  .mg-cap-feat {
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  /* ── Pricing FAQ ──────────────────────────────────────────── */
+  .mg-price-faq {
+    max-width: 860px;
+    margin: 64px auto 0;
+  }
+  .mg-price-faq-head {
+    text-align: center;
+    margin-bottom: 32px;
+  }
+  .mg-price-faq-head .kicker {
+    display: block;
+  }
+</style>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -351,6 +351,10 @@ const pricingFaqs = [
 
     <!-- ── Community panel ─────────────────────────────────────── -->
     <div class="mg-tabpanel" data-panel="community" role="tabpanel" hidden>
+      <p class="mg-panel-intro">
+        Free and open source, forever. Run the full platform on your own
+        hardware and keep complete control of your data.
+      </p>
       <div class="mg-ce-card cta-card">
         <div class="mg-ce-main">
           <span class="label">Community Edition · Free</span>
@@ -370,7 +374,7 @@ const pricingFaqs = [
               href="https://github.com/absmach/magistrala"
               class="btn btn-primary"
               target="_blank"
-              rel="noopener">Install ↗</a
+              rel="noopener">Get started ↗</a
             >
             <a
               href="https://www.absmach.eu/docs/magistrala"
@@ -590,7 +594,7 @@ const pricingFaqs = [
         messages”, no “3 dashboards”. You either have a feature or you don't.
         Once you're licensed, the only limits are soft ones, set by your
         hardware and configuration — never by us. And every deployment, Private
-        Cloud or self-managed, is a full, dedicated instance. Never shared.
+        Cloud or self-managed, is a full, dedicated instance.
       </p>
     </div>
 

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -15,6 +15,7 @@ const privateTiers = [
       "Pilot projects and small deployments with low message bandwidth and non-critical message loss.",
     monthly: 150,
     annual: 1620,
+    storage: "80 GB storage for messages",
     transfer: "3 TB data transfer",
     capacity: "~200 devices · 1M messages / month",
     inherits: null,
@@ -37,6 +38,7 @@ const privateTiers = [
       "Deployments where availability matters and flexibility and features are important. This is where your business starts.",
     monthly: 500,
     annual: 5400,
+    storage: "180 GB storage for messages",
     transfer: "8 TB data transfer",
     capacity: "~10k devices · 100M messages / month",
     inherits: "Prototype",
@@ -57,6 +59,7 @@ const privateTiers = [
     goodFor: "Larger deployments where stability and performance matter.",
     monthly: 1000,
     annual: 10800,
+    storage: "300 GB storage for messages",
     transfer: "8 TB data transfer",
     capacity: "~100k devices · 1B messages / month",
     inherits: "Business",
@@ -75,6 +78,7 @@ const privateTiers = [
       "Large production deployments where HA and SLA matter — huge device and message volumes, no acceptable message loss, and strict data residency and compliance.",
     monthly: null,
     annual: null,
+    storage: null,
     transfer: null,
     capacity: null,
     inherits: null,
@@ -270,7 +274,7 @@ const pricingFaqs = [
           </div>
         </div>
         <div class="mg-ce-visual" aria-hidden="true">
-          <Boxes size={120} strokeWidth={1} />
+          <Boxes size={120} />
         </div>
       </div>
     </div>
@@ -339,6 +343,7 @@ const pricingFaqs = [
                   <li>→ {feature}</li>
                 ))}
                 {tier.capacity && <li class="mg-cap-feat">→ {tier.capacity}</li>}
+                {tier.storage && <li>→ {tier.storage}</li>}
                 {tier.transfer && (
                   <li>
                     → {tier.transfer}

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -116,7 +116,6 @@ const eeFeatures = [
   "Alarms",
   "Reports",
   "Audit logs",
-  "Priority security patches & updates",
 ];
 
 // ── Compare Community with the Private Cloud tiers ─────────────────
@@ -124,7 +123,6 @@ const eeFeatures = [
 // true → included, false → not included, string → specific value.
 // Self-hosted Community is bounded only by your own hardware.
 const compareCols = ["Community", "Prototype", "Business", "Enterprise", "Custom"];
-const HW = "Your hardware";
 const compareGroups = [
   {
     group: "Platform",
@@ -151,15 +149,15 @@ const compareGroups = [
   {
     group: "Capacity",
     rows: [
-      { f: "Devices", cells: [HW, "~200", "~5k", "~50k", "Custom"] },
-      { f: "Messages / month", cells: [HW, "~1M", "~10M", "~100M", "Custom"] },
+      { f: "Devices", cells: [false, "~200", "~5k", "~50k", "Custom"] },
+      { f: "Messages / month", cells: [false, "~1M", "~10M", "~100M", "Custom"] },
       {
         f: "Message storage",
-        cells: [HW, "80 GB", "180 GB", "300 GB", "Custom"],
+        cells: [false, "80 GB", "180 GB", "300 GB", "Custom"],
       },
       {
         f: "Data transfer / month",
-        cells: [HW, "3 TB", "8 TB", "8 TB", "Custom"],
+        cells: [false, "3 TB", "8 TB", "8 TB", "Custom"],
       },
     ],
   },
@@ -539,6 +537,16 @@ const pricingFaqs = [
           <ul class="mg-price-feats">
             <li class="mg-inherit">Everything in Community Edition, plus:</li>
             {eeFeatures.map((f) => <li>→ {f}</li>)}
+            <li>
+              → Priority security patches &amp;{" "}
+              <span
+                class="mg-term"
+                data-term-monthly="updates"
+                data-term-perpetual="updates for the purchased version"
+              >
+                updates
+              </span>
+            </li>
             <li class="mg-cap-feat">
               → No limits — unlimited devices, messages, and features
             </li>
@@ -719,6 +727,12 @@ const pricingFaqs = [
           .forEach((n) => {
             const t = n.dataset[`note${cap(mode)}`];
             if (t !== undefined) n.textContent = t;
+          });
+        scope
+          .querySelectorAll<HTMLElement>(".mg-term")
+          .forEach((el) => {
+            const t = el.dataset[`term${cap(mode)}`];
+            if (t !== undefined) el.textContent = t;
           });
       }),
     );

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -115,7 +115,21 @@ const eeFeatures = [
 const pricingFaqs = [
   {
     q: "What's the difference between Community, Private Cloud, and Self-managed?",
-    a: "Community Edition is the free platform you run yourself. In includes a free and open-source version of the backend services, and a free version of the UI. Private Cloud is a fully managed, dedicated instance we host and operate for you. Self-managed is Magistrala Enterprise Edition running in your own environment — either licensed to you to operate, or deployed and operated by us on your infrastructure.",
+    a: "Same platform, three ways to run it:",
+    bullets: [
+      {
+        label: "Community",
+        text: "the free, open-source edition (Apache 2.0) you run yourself — the backend services plus a free, open-source version of the UI.",
+      },
+      {
+        label: "Private Cloud",
+        text: "a fully managed, dedicated instance of Magistrala Enterprise Edition that we host and operate for you.",
+      },
+      {
+        label: "Self-managed",
+        text: "Magistrala Enterprise Edition in your own environment — licensed to you to run yourself, or deployed and operated by us on your infrastructure.",
+      },
+    ],
   },
   {
     q: "What's included in a Private Cloud plan?",

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -599,11 +599,6 @@ const pricingFaqs = [
         <h3 class="h-3" style="margin-top:12px;">
           Community vs Private Cloud plans.
         </h3>
-        <p class="mg-compare-sub">
-          Everything in the free Community Edition, plus what each managed
-          Private Cloud tier adds. Self-hosted Community is bounded only by your
-          own hardware.
-        </p>
       </div>
       <div class="mg-compare-scroll">
         <table class="mg-compare-table">
@@ -1062,12 +1057,6 @@ const pricingFaqs = [
   }
   .mg-compare-head .kicker {
     display: block;
-  }
-  .mg-compare-sub {
-    margin: 12px auto 0;
-    max-width: 60ch;
-    font-size: 15px;
-    color: var(--ink-2);
   }
   .mg-compare-scroll {
     overflow-x: auto;

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -117,32 +117,46 @@ const eeFeatures = [
   "Priority security patches & updates",
 ];
 
-// ── Community vs Enterprise Edition comparison ─────────────────────
-// Enterprise Edition ships at two service levels, mirrored by the
-// Business and Enterprise plans. Cell values: true → included,
-// false → not included, string → the specific value for that column.
+// ── Compare Community with the Private Cloud tiers ─────────────────
+// Columns: Community + every Private Cloud tier. Cell values:
+// true → included, false → not included, string → specific value.
+// Self-hosted Community is bounded only by your own hardware.
+const compareCols = ["Community", "Prototype", "Business", "Enterprise", "Custom"];
+const HW = "Your hardware";
 const compareGroups = [
   {
     group: "Platform",
     rows: [
-      { f: "Open-source backend (Apache 2.0)", ce: true, biz: true, ent: true },
+      {
+        f: "Open-source backend (Apache 2.0)",
+        cells: [true, true, true, true, true],
+      },
       {
         f: "Multi-protocol messaging (MQTT, CoAP, HTTP, WebSocket)",
-        ce: true,
-        biz: true,
-        ent: true,
+        cells: [true, true, true, true, true],
       },
       {
         f: "Multi-tenancy & fine-grained access control",
-        ce: true,
-        biz: true,
-        ent: true,
+        cells: [true, true, true, true, true],
       },
       {
         f: "Unlimited clients, channels, groups & messages",
-        ce: true,
-        biz: true,
-        ent: true,
+        cells: [true, true, true, true, true],
+      },
+    ],
+  },
+  {
+    group: "Capacity",
+    rows: [
+      { f: "Devices", cells: [HW, "~200", "~10k", "~100k", "Custom"] },
+      { f: "Messages / month", cells: [HW, "1M", "100M", "1B", "Custom"] },
+      {
+        f: "Message storage",
+        cells: [HW, "80 GB", "180 GB", "300 GB", "Custom"],
+      },
+      {
+        f: "Data transfer / month",
+        cells: [HW, "3 TB", "8 TB", "8 TB", "Custom"],
       },
     ],
   },
@@ -151,12 +165,16 @@ const compareGroups = [
     rows: [
       {
         f: "User interface",
-        ce: "Free community UI",
-        biz: "Commercial + whitelabel",
-        ent: "Commercial + whitelabel",
+        cells: [
+          "Free community UI",
+          "Commercial + whitelabel",
+          "Commercial + whitelabel",
+          "Commercial + whitelabel",
+          "Commercial + whitelabel",
+        ],
       },
-      { f: "Dashboards", ce: false, biz: true, ent: true },
-      { f: "Audit logs", ce: false, biz: true, ent: true },
+      { f: "Dashboards", cells: [false, true, true, true, true] },
+      { f: "Audit logs", cells: [false, true, true, true, true] },
     ],
   },
   {
@@ -164,12 +182,10 @@ const compareGroups = [
     rows: [
       {
         f: "Rules Engine & custom message formats",
-        ce: false,
-        biz: true,
-        ent: true,
+        cells: [false, false, true, true, true],
       },
-      { f: "Alarms", ce: false, biz: true, ent: true },
-      { f: "Reports", ce: false, biz: true, ent: true },
+      { f: "Alarms", cells: [false, false, true, true, true] },
+      { f: "Reports", cells: [false, false, true, true, true] },
     ],
   },
   {
@@ -177,39 +193,35 @@ const compareGroups = [
     rows: [
       {
         f: "Security patches & updates",
-        ce: "Community",
-        biz: "Priority",
-        ent: "Priority",
+        cells: ["Community", "Standard", "Priority", "Priority", "Priority"],
       },
       {
         f: "Support",
-        ce: "Community",
-        biz: "Priority",
-        ent: "Highest priority",
+        cells: [
+          "Community",
+          "Community",
+          "Priority",
+          "Highest priority",
+          "Highest priority",
+        ],
       },
       {
         f: "Dedicated support hours",
-        ce: false,
-        biz: "2h / month",
-        ent: "12h / month",
+        cells: [false, false, "2h / month", "12h / month", "Custom"],
       },
       {
         f: "Backups",
-        ce: false,
-        biz: "Weekly · 3-month retention",
-        ent: "Daily · 3-month retention",
+        cells: [
+          false,
+          false,
+          "Weekly · 3-month",
+          "Daily · 3-month",
+          "Custom",
+        ],
       },
       {
         f: "Dedicated instance",
-        ce: "Self-hosted",
-        biz: true,
-        ent: true,
-      },
-      {
-        f: "Uptime SLA & high-availability clustering",
-        ce: false,
-        biz: false,
-        ent: false,
+        cells: ["Self-hosted", true, true, true, true],
       },
     ],
   },
@@ -588,14 +600,14 @@ const pricingFaqs = [
     <!-- ── Compare editions ────────────────────────────────────── -->
     <div class="mg-compare">
       <div class="mg-compare-head">
-        <span class="kicker">Editions</span>
+        <span class="kicker">Editions &amp; plans</span>
         <h3 class="h-3" style="margin-top:12px;">
-          Community vs Enterprise Edition.
+          Community vs Private Cloud plans.
         </h3>
         <p class="mg-compare-sub">
-          Enterprise Edition powers both the managed Private Cloud plans and
-          self-managed licenses, at two service levels — Business and
-          Enterprise.
+          Everything in the free Community Edition, plus what each managed
+          Private Cloud tier adds. Self-hosted Community is bounded only by your
+          own hardware.
         </p>
       </div>
       <div class="mg-compare-scroll">
@@ -603,9 +615,9 @@ const pricingFaqs = [
           <thead>
             <tr>
               <th scope="col">Feature</th>
-              <th scope="col">Community</th>
-              <th scope="col">EE · Business</th>
-              <th scope="col">EE · Enterprise</th>
+              {compareCols.map((c) => (
+                <th scope="col">{c}</th>
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -613,14 +625,14 @@ const pricingFaqs = [
               compareGroups.map((grp) => (
                 <Fragment>
                   <tr class="mg-compare-group">
-                    <th scope="colgroup" colspan="4">
+                    <th scope="colgroup" colspan={compareCols.length + 1}>
                       {grp.group}
                     </th>
                   </tr>
                   {grp.rows.map((row) => (
                     <tr>
                       <th scope="row">{row.f}</th>
-                      {[row.ce, row.biz, row.ent].map((c) => (
+                      {row.cells.map((c) => (
                         <td>
                           {typeof c === "boolean" ? (
                             c ? (
@@ -644,8 +656,9 @@ const pricingFaqs = [
         </table>
       </div>
       <p class="mg-compare-foot">
-        A formal uptime SLA and high-availability clustering are available on the
-        Custom plan (and self-managed “Managed by us”) only.
+        Capacity figures are soft guidance bounded by hardware, not hard caps. A
+        formal uptime SLA and high-availability clustering are available on the
+        Custom plan only.
       </p>
     </div>
 
@@ -1041,7 +1054,7 @@ const pricingFaqs = [
 
   /* ── Compare editions table ───────────────────────────────── */
   .mg-compare {
-    max-width: 960px;
+    max-width: 1120px;
     margin: 72px auto 0;
   }
   .mg-compare-head {
@@ -1064,7 +1077,7 @@ const pricingFaqs = [
   }
   .mg-compare-table {
     width: 100%;
-    min-width: 620px;
+    min-width: 880px;
     border-collapse: collapse;
     font-size: 14px;
   }
@@ -1085,7 +1098,7 @@ const pricingFaqs = [
     text-align: left;
   }
   .mg-compare-table thead th:first-child {
-    width: 40%;
+    width: 26%;
   }
   .mg-compare-table tbody th[scope="row"] {
     font-weight: 500;

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -654,6 +654,11 @@ const pricingFaqs = [
         formal uptime SLA and high-availability clustering are available on the
         Custom plan only.
       </p>
+      <p class="mg-compare-note">
+        No license keys, no activation, no phone-home. We don't lock your
+        deployment or track your activity, so your data never leaves the
+        deployments you choose.
+      </p>
     </div>
 
     <!-- ── Shared pricing FAQ ──────────────────────────────────── -->
@@ -1127,5 +1132,17 @@ const pricingFaqs = [
     text-align: center;
     font-size: 13px;
     color: var(--ink-3);
+  }
+  .mg-compare-note {
+    max-width: 760px;
+    margin: 20px auto 0;
+    padding: 16px 22px;
+    border: 1px solid var(--line-3);
+    border-radius: var(--radius);
+    background: var(--paper-2);
+    text-align: center;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--ink-2);
   }
 </style>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -104,9 +104,10 @@ const privateTiers = [
 
 // ── Community Edition (free, open source) ──────────────────────────
 const communityFeatures = [
-  "Unlimited devices and assets",
-  "Unlimited software updates",
-  "Ability to contribute",
+  "Unlimited clients, channels, groups, tenants, messages",
+  "Every update, free forever",
+  "Full control of your data and infrastructure",
+  "Open source under Apache 2.0 — no lock-in",
   "Community support",
 ];
 
@@ -119,7 +120,6 @@ const eeFeatures = [
   "Reports",
   "Audit logs",
   "Priority security patches & updates",
-  "Enterprise support",
 ];
 
 const pricingFaqs = [
@@ -238,12 +238,13 @@ const pricingFaqs = [
       <div class="mg-ce-card cta-card">
         <div class="mg-ce-main">
           <span class="label">Community Edition · Free</span>
-          <h3 class="mg-ce-title">Your free ticket to IoT.</h3>
+          <h3 class="mg-ce-title">Free — and it always will be.</h3>
           <p class="mg-ce-desc">
-            Get started with Community Edition (CE): a free, open-source (Apache
-            2.0) IoT platform. A powerful, scalable, multi-tenant solution for
-            collecting, processing, visualizing, and managing your IoT data and
-            devices with maximum agility.
+            The Community Edition is the open-source core of Magistrala, released
+            under Apache 2.0. Run the full multi-tenant IoT platform on your own
+            hardware, keep complete control of your data and deployment, and
+            build without license fees, seat limits, or vendor lock-in. It's
+            yours to run, extend, and own.
           </p>
           <ul class="mg-ce-feats">
             {communityFeatures.map((f) => <li>→ {f}</li>)}
@@ -333,7 +334,12 @@ const pricingFaqs = [
                   <li>→ {feature}</li>
                 ))}
                 {tier.capacity && <li class="mg-cap-feat">→ {tier.capacity}</li>}
-                {tier.transfer && <li>→ {tier.transfer}</li>}
+                {tier.transfer && (
+                  <li>
+                    → {tier.transfer}
+                    <span class="mg-ast">*</span>
+                  </li>
+                )}
               </ul>
               <a
                 href="/contact"
@@ -348,7 +354,13 @@ const pricingFaqs = [
       </div>
 
       <p
-        style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
+        style="margin-top:32px; text-align:center; font-size:13px; color:var(--ink-3);"
+      >
+        * Data transfer is a soft guide — extra transfer is billed at €20 per
+        additional TB / month.
+      </p>
+      <p
+        style="margin-top:8px; text-align:center; font-size:14px; color:var(--ink-3);"
       >
         Need more than 100k devices or a bespoke setup?{" "}
         <a href="/contact" style="color:inherit; text-decoration:underline;"
@@ -406,6 +418,10 @@ const pricingFaqs = [
           <ul class="mg-price-feats">
             <li class="mg-inherit">Everything in Community Edition, plus:</li>
             {eeFeatures.map((f) => <li>→ {f}</li>)}
+            <li class="mg-cap-feat">
+              → No limits — unlimited devices, messages, and features
+            </li>
+            <li class="mg-excl">Support not included — purchased separately</li>
           </ul>
           <a
             href="/contact"
@@ -775,6 +791,16 @@ const pricingFaqs = [
   .mg-cap-feat {
     font-weight: 600;
     color: var(--ink);
+  }
+  .mg-ast {
+    color: var(--ink-3);
+  }
+  .mg-excl {
+    margin-top: 4px;
+    padding-top: 12px;
+    border-top: 1px solid var(--line-3);
+    font-size: 12.5px;
+    color: var(--ink-3);
   }
 
   /* Self-managed cards have shorter descriptions — relax the min-height */

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -31,7 +31,6 @@ const privateTiers = [
       "Security fixes",
       "Community support",
       "Dashboards",
-      "Audit logs",
     ],
   },
   {
@@ -164,12 +163,12 @@ const compareGroups = [
   {
     group: "Interface & data",
     rows: [
+      { f: "Audit logs", cells: [true, true, true, true, true] },
       {
         f: "Commercial UI with whitelabeling",
         cells: [false, true, true, true, true],
       },
       { f: "Dashboards", cells: [false, true, true, true, true] },
-      { f: "Audit logs", cells: [false, true, true, true, true] },
     ],
   },
   {

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -10,36 +10,26 @@ const { showHead = true } = Astro.props;
 // ── Private Cloud: fully managed, dedicated instances ──────────────
 const privateTiers = [
   {
-    name: "Starter",
-    goodFor: "Small proofs of concept and testing.",
-    monthly: 50,
-    annual: 540,
+    name: "Prototype",
+    goodFor:
+      "Pilot projects and small deployments with low message bandwidth and non-critical message loss.",
+    monthly: 150,
+    annual: 1620,
     transfer: "3 TB data transfer",
-    capacity: "~50 devices · 100k messages / month",
+    capacity: "~200 devices · 1M messages / month",
     inherits: null,
     featured: false,
     contact: false,
     cta: "Get started",
     features: [
       "Commercial UI with whitelabeling",
-      "Basic UI patches",
+      "Basic UI and Backend patches",
+      "Security updates",
       "Security fixes",
       "Community support",
+      "Dashboards",
+      "Audit logs",
     ],
-  },
-  {
-    name: "Prototype",
-    goodFor:
-      "Pilot projects and small deployments with low message bandwidth, where occasional message loss is acceptable.",
-    monthly: 200,
-    annual: 2160,
-    transfer: "5 TB data transfer",
-    capacity: "~250 devices · 1M messages / month",
-    inherits: "Starter",
-    featured: false,
-    contact: false,
-    cta: "Get started",
-    features: ["UI and backend updates", "Dashboards", "Audit logs"],
   },
   {
     name: "Business",
@@ -125,11 +115,11 @@ const eeFeatures = [
 const pricingFaqs = [
   {
     q: "What's the difference between Community, Private Cloud, and Self-managed?",
-    a: "Community Edition is the free, open-source platform you run yourself. Private Cloud is a fully managed, dedicated instance we host and operate for you. Self-managed is Magistrala Enterprise Edition running in your own environment — either licensed to you to operate, or deployed and operated by us on your infrastructure.",
+    a: "Community Edition is the free platform you run yourself. In includes a free and open-source version of the backend services, and a free version of the UI. Private Cloud is a fully managed, dedicated instance we host and operate for you. Self-managed is Magistrala Enterprise Edition running in your own environment — either licensed to you to operate, or deployed and operated by us on your infrastructure.",
   },
   {
     q: "What's included in a Private Cloud plan?",
-    a: "Every Private Cloud tier covers hosting, deployment, monitoring, and the updates listed for that tier. Higher tiers add dashboards, audit logs, rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
+    a: "Every Private Cloud tier covers license, hosting, deployment, monitoring, dashboards, audit logs, and the updates listed for that tier. Higher tiers add the rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
   },
   {
     q: "What counts as a device?",
@@ -140,7 +130,7 @@ const pricingFaqs = [
     a: "Yes. Every Private Cloud plan runs on a dedicated instance — no shared infrastructure. We provision, run, and manage the instance for you.",
   },
   {
-    q: "What does “~250 devices · 1M messages / month” actually mean?",
+    q: "What does “~200 devices · 1M messages / month” actually mean?",
     a: "Because each tier is a dedicated instance, that figure is a rough estimate of how many concurrent devices and messages the instance can comfortably handle. It is not a hard cap — we don't limit you artificially; the only real limit is the hardware and how it's set up. We deliberately avoid a messages-per-second metric, because it's a weak and misleading number for a few reasons:",
     points: [
       "Message size varies enormously. A ping is a message, and so is a 100 MB binary upload — they don't cost the same, and they aren't the same priority.",
@@ -163,15 +153,15 @@ const pricingFaqs = [
   },
   {
     q: "What's the difference between a monthly and a perpetual self-managed license?",
-    a: "A monthly license (€300 per cluster) is billed each month for as long as you use it. A perpetual license (€3,999 per cluster) is a one-time payment that lets you keep running that version indefinitely. Both cover the full Magistrala Enterprise Edition feature set.",
+    a: "A monthly license (€300 per cluster) is billed each month for as long as you use it. A perpetual license (€3,999) is a one-time payment that lets you keep running that version indefinitely. Both cover a single cluster deployment of the full Magistrala Enterprise Edition feature set.",
   },
   {
     q: "Can I deploy on my own cloud or on-premises?",
-    a: "Yes. With a self-managed license you run Magistrala Enterprise yourself, anywhere. With the “Managed by us” option we deploy and operate it on your infrastructure — AWS, GCP, Azure, or on-premises, including air-gapped environments — aligned to your SLA, security, and data-residency policies.",
+    a: "Yes. With a self-managed license you run Magistrala Enterprise yourself, anywhere. With the “Self-managed” option we deploy and operate it on your infrastructure — AWS, GCP, Azure, or on-premises, including air-gapped environments — aligned to your SLA, security, and data-residency policies.",
   },
   {
     q: "Do you offer a custom SLA and high availability?",
-    a: "Yes. Private Cloud Enterprise and Custom plans, and self-managed “Managed by us” deployments, support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the plan and are tailored to your requirements.",
+    a: "Yes. Private Cloud Enterprise and Custom plans, and self-managed “Self-managed” deployments, support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the plan and are tailored to your requirements.",
   },
   {
     q: "Is self-hosting free?",
@@ -620,16 +610,13 @@ const pricingFaqs = [
   /* ── Pricing grid (Private Cloud) ─────────────────────────── */
   .mg-pricing-grid {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: 16px;
     align-items: stretch;
+    max-width: 1080px;
+    margin: 0 auto;
   }
-  @media (max-width: 1200px) {
-    .mg-pricing-grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-  @media (max-width: 820px) {
+  @media (max-width: 1024px) {
     .mg-pricing-grid {
       grid-template-columns: repeat(2, 1fr);
     }

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -121,7 +121,13 @@ const eeFeatures = [
 // Columns: Community + every Private Cloud tier. Cell values:
 // true → included, false → not included, string → specific value.
 // Self-hosted Community is bounded only by your own hardware.
-const compareCols = ["Community", "Prototype", "Business", "Enterprise", "Custom"];
+const compareCols = [
+  "Community",
+  "Prototype",
+  "Business",
+  "Enterprise",
+  "Custom",
+];
 const compareGroups = [
   {
     group: "Platform",
@@ -149,7 +155,10 @@ const compareGroups = [
     group: "Capacity",
     rows: [
       { f: "Devices", cells: [false, "~200", "~5k", "~50k", "Custom"] },
-      { f: "Messages / month", cells: [false, "~1M", "~10M", "~100M", "Custom"] },
+      {
+        f: "Messages / month",
+        cells: [false, "~1M", "~10M", "~100M", "Custom"],
+      },
       {
         f: "Message storage",
         cells: [false, "80 GB", "180 GB", "300 GB", "Custom"],
@@ -205,13 +214,7 @@ const compareGroups = [
       },
       {
         f: "Backups",
-        cells: [
-          false,
-          false,
-          "Weekly · 3-month",
-          "Daily · 3-month",
-          "Custom",
-        ],
+        cells: [false, false, "Weekly · 3-month", "Daily · 3-month", "Custom"],
       },
       {
         f: "Dedicated instance",
@@ -396,8 +399,10 @@ const pricingFaqs = [
 
       <div class="mg-price-wrap">
         <div class="mg-price-toggle" role="group" aria-label="Billing period">
-          <button type="button" class="mg-price-opt is-active" data-billing="monthly"
-            >Monthly</button
+          <button
+            type="button"
+            class="mg-price-opt is-active"
+            data-billing="monthly">Monthly</button
           >
           <button type="button" class="mg-price-opt" data-billing="annual"
             >Annual <span class="mg-save">Save 10%</span></button
@@ -423,7 +428,9 @@ const pricingFaqs = [
                         <span
                           class="mg-amount"
                           data-amt-monthly={fmt(tier.monthly ?? 0)}
-                          data-amt-annual={fmt(Math.round((tier.annual ?? 0) / 12))}
+                          data-amt-annual={fmt(
+                            Math.round((tier.annual ?? 0) / 12),
+                          )}
                         >
                           €{fmt(tier.monthly ?? 0)}
                         </span>
@@ -445,12 +452,16 @@ const pricingFaqs = [
               </div>
               <ul class="mg-price-feats">
                 {tier.inherits && (
-                  <li class="mg-inherit">Everything in {tier.inherits}, plus:</li>
+                  <li class="mg-inherit">
+                    Everything in {tier.inherits}, plus:
+                  </li>
                 )}
                 {tier.features.map((feature) => (
                   <li>→ {feature}</li>
                 ))}
-                {tier.capacity && <li class="mg-cap-feat">→ {tier.capacity}</li>}
+                {tier.capacity && (
+                  <li class="mg-cap-feat">→ {tier.capacity}</li>
+                )}
                 {tier.storage && <li>→ {tier.storage}</li>}
                 {tier.transfer && (
                   <li>
@@ -509,8 +520,10 @@ const pricingFaqs = [
 
       <div class="mg-price-wrap">
         <div class="mg-price-toggle" role="group" aria-label="License term">
-          <button type="button" class="mg-price-opt is-active" data-billing="monthly"
-            >Monthly</button
+          <button
+            type="button"
+            class="mg-price-opt is-active"
+            data-billing="monthly">Monthly</button
           >
           <button type="button" class="mg-price-opt" data-billing="perpetual"
             >Perpetual</button
@@ -582,8 +595,8 @@ const pricingFaqs = [
               </div>
             </div>
             <div class="mg-goodfor">
-              We deploy and operate Magistrala Enterprise on your infrastructure,
-              aligned to your SLA, security, and data policies.
+              We deploy and operate Magistrala Enterprise on your
+              infrastructure, aligned to your SLA, security, and data policies.
             </div>
           </div>
           <ul class="mg-price-feats">
@@ -618,9 +631,7 @@ const pricingFaqs = [
           <thead>
             <tr>
               <th scope="col">Feature</th>
-              {compareCols.map((c) => (
-                <th scope="col">{c}</th>
-              ))}
+              {compareCols.map((c) => <th scope="col">{c}</th>)}
             </tr>
           </thead>
           <tbody>
@@ -708,34 +719,30 @@ const pricingFaqs = [
   );
 
   // Billing / term toggles (scoped to their own panel)
-  document.querySelectorAll<HTMLElement>(".mg-price-toggle").forEach((toggle) => {
-    const opts = toggle.querySelectorAll<HTMLButtonElement>(".mg-price-opt");
-    const scope: ParentNode = toggle.closest(".mg-tabpanel") ?? document;
-    opts.forEach((opt) =>
-      opt.addEventListener("click", () => {
-        const mode = opt.dataset.billing ?? "monthly";
-        opts.forEach((o) => o.classList.toggle("is-active", o === opt));
-        scope
-          .querySelectorAll<HTMLElement>(".mg-amount")
-          .forEach((a) => {
+  document
+    .querySelectorAll<HTMLElement>(".mg-price-toggle")
+    .forEach((toggle) => {
+      const opts = toggle.querySelectorAll<HTMLButtonElement>(".mg-price-opt");
+      const scope: ParentNode = toggle.closest(".mg-tabpanel") ?? document;
+      opts.forEach((opt) =>
+        opt.addEventListener("click", () => {
+          const mode = opt.dataset.billing ?? "monthly";
+          opts.forEach((o) => o.classList.toggle("is-active", o === opt));
+          scope.querySelectorAll<HTMLElement>(".mg-amount").forEach((a) => {
             const v = a.dataset[`amt${cap(mode)}`];
             if (v !== undefined) a.textContent = `€${v}`;
           });
-        scope
-          .querySelectorAll<HTMLElement>(".mg-price-note")
-          .forEach((n) => {
+          scope.querySelectorAll<HTMLElement>(".mg-price-note").forEach((n) => {
             const t = n.dataset[`note${cap(mode)}`];
             if (t !== undefined) n.textContent = t;
           });
-        scope
-          .querySelectorAll<HTMLElement>(".mg-term")
-          .forEach((el) => {
+          scope.querySelectorAll<HTMLElement>(".mg-term").forEach((el) => {
             const t = el.dataset[`term${cap(mode)}`];
             if (t !== undefined) el.textContent = t;
           });
-      }),
-    );
-  });
+        }),
+      );
+    });
 </script>
 
 <style>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -485,6 +485,19 @@ const pricingFaqs = [
           >Talk to us</a
         >.
       </p>
+
+      <!-- ── Emphasis: no artificial gates ───────────────────────── -->
+      <div class="mg-emphasis">
+        <span class="mg-emphasis-kicker">No artificial gates</span>
+        <h3 class="mg-emphasis-title">Features, not fences.</h3>
+        <p>
+          We don't meter you with arbitrary caps — no “10 devices”, no “400
+          messages”, no “3 dashboards”. You either have a feature or you don't.
+          Once you're licensed, the only limits are soft ones, set by your
+          hardware and configuration — never by us. And every deployment,
+          Private Cloud or self-managed, is a full, dedicated instance.
+        </p>
+      </div>
     </div>
 
     <!-- ── Self-managed panel ──────────────────────────────────── -->
@@ -590,19 +603,6 @@ const pricingFaqs = [
           </a>
         </div>
       </div>
-    </div>
-
-    <!-- ── Emphasis: no artificial gates ───────────────────────── -->
-    <div class="mg-emphasis">
-      <span class="mg-emphasis-kicker">No artificial gates</span>
-      <h3 class="mg-emphasis-title">Features, not fences.</h3>
-      <p>
-        We don't meter you with arbitrary caps — no “10 devices”, no “400
-        messages”, no “3 dashboards”. You either have a feature or you don't.
-        Once you're licensed, the only limits are soft ones, set by your
-        hardware and configuration — never by us. And every deployment, Private
-        Cloud or self-managed, is a full, dedicated instance.
-      </p>
     </div>
 
     <!-- ── Compare editions ────────────────────────────────────── -->

--- a/src/pages/magistrala/pricing.astro
+++ b/src/pages/magistrala/pricing.astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
-import Pricing from "../components/Pricing.astro";
-import FinalCTA from "../components/FinalCTA.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import Pricing from "../../components/Pricing.astro";
+import FinalCTA from "../../components/FinalCTA.astro";
 ---
 
 <BaseLayout

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -18,13 +18,12 @@ import FinalCTA from "../components/FinalCTA.astro";
       <div class="container-narrow" style="text-align:center;">
         <span class="kicker">Pricing</span>
         <h1 class="h-1" style="margin-top:14px;">
-          Managed Magistrala, priced to scale.
+          Choose how you run Magistrala.
         </h1>
         <p class="lede" style="margin:20px auto 0;">
-          Fully managed, dedicated instances with hosting, updates, and support.
-          Start small and move up as your fleet grows — or bring your own cloud
-          with a custom plan. Prefer to run it yourself? The open-source core is
-          free.
+          Free and open source, fully managed in our private cloud, or
+          self-managed in your own environment — the same platform, priced for
+          the way you want to operate it.
         </p>
         <div class="btn-row" style="justify-content:center; margin-top:28px;">
           <a

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,0 +1,45 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import Pricing from "../components/Pricing.astro";
+import FinalCTA from "../components/FinalCTA.astro";
+---
+
+<BaseLayout
+  title="Pricing — Managed Magistrala IoT Platform"
+  description="Managed Magistrala pricing: five plans from Starter to Custom, each a dedicated instance with hosting, updates, and support. Monthly or annual billing, or self-host the open-source core for free."
+  ogImage="/img/og/og-magistrala.png"
+  ogImageAlt="Magistrala Pricing"
+>
+  <Header />
+  <main>
+    <section class="section" style="padding-bottom:0;">
+      <div class="container-narrow" style="text-align:center;">
+        <span class="kicker">Pricing</span>
+        <h1 class="h-1" style="margin-top:14px;">
+          Managed Magistrala, priced to scale.
+        </h1>
+        <p class="lede" style="margin:20px auto 0;">
+          Fully managed, dedicated instances with hosting, updates, and support.
+          Start small and move up as your fleet grows — or bring your own cloud
+          with a custom plan. Prefer to run it yourself? The open-source core is
+          free.
+        </p>
+        <div class="btn-row" style="justify-content:center; margin-top:28px;">
+          <a
+            href="https://cloud.magistrala.absmach.eu"
+            class="btn btn-primary"
+            target="_blank"
+            rel="noopener">Start for Free ↗</a
+          >
+          <a href="/contact" class="btn">Contact Sales →</a>
+        </div>
+      </div>
+    </section>
+
+    <Pricing showHead={false} />
+    <FinalCTA />
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -8,7 +8,7 @@ import FinalCTA from "../components/FinalCTA.astro";
 
 <BaseLayout
   title="Pricing — Managed Magistrala IoT Platform"
-  description="Managed Magistrala pricing: five plans from Starter to Custom, each a dedicated instance with hosting, updates, and support. Monthly or annual billing, or self-host the open-source core for free."
+  description="Magistrala pricing across three models: the free, open-source Community Edition, fully managed Private Cloud plans, and self-managed Enterprise licensing. Monthly, annual, or perpetual billing."
   ogImage="/img/og/og-magistrala.png"
   ogImageAlt="Magistrala Pricing"
 >

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -108,7 +108,7 @@ const faqs = [
   {
     q: "Can I self-host Magistrala?",
     a: "Yes. The Magistrala backend is open source under the Apache 2.0 license, and the Community Edition — the open-source backend plus a free-to-use UI you deploy as a Docker container — is free to self-host on your own infrastructure, a private cloud, or on-premises (Docker Compose and Kubernetes manifests included). The Enterprise Edition — which adds the rules engine, alarms, reports, audit logs, and dashboards — is a commercial edition. If you would rather not run it yourself, we offer fully managed plans.",
-    link: { href: "/pricing", label: "View managed pricing" },
+    link: { href: "/magistrala/pricing/", label: "View managed pricing" },
   },
   {
     q: "What protocols does Magistrala support?",
@@ -121,7 +121,7 @@ const faqs = [
   {
     q: "Is there a free option, and what does the managed cloud cost?",
     a: "The open-source core and Community Edition are free to self-host forever, and you can start for free on the shared cloud to evaluate the platform. For production, managed Private Cloud plans run on dedicated instances — starting at €150/month, up to Enterprise, plus a Custom plan for large or regulated deployments. You can also self-manage Magistrala Enterprise Edition under your own license.",
-    link: { href: "/pricing", label: "See all plans" },
+    link: { href: "/magistrala/pricing/", label: "See all plans" },
   },
   {
     q: "How is Magistrala different from a plain MQTT broker?",

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -851,30 +851,32 @@ const faqSchema = JSON.stringify({
                 class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}${tier.contact ? " is-custom" : ""}`}
               >
                 {tier.featured && <span class="mg-badge">Popular</span>}
-                <div>
+                <div class="mg-price-head">
                   <div class="label">{tier.name}</div>
-                  <div class="mg-goodfor">{tier.goodFor}</div>
-                  <div class="mg-price">
-                    {tier.contact ? (
-                      <span class="mg-price-contact">Contact</span>
-                    ) : (
-                      <Fragment>
-                        <span
-                          class="mg-amount"
-                          data-monthly={tier.monthly}
-                          data-annual={Math.round((tier.annual ?? 0) / 12)}
-                        >
-                          €{tier.monthly}
-                        </span>
-                        <span class="mg-per">/ month</span>
-                      </Fragment>
+                  <div class="mg-price-block">
+                    <div class="mg-price">
+                      {tier.contact ? (
+                        <span class="mg-price-contact">Contact</span>
+                      ) : (
+                        <Fragment>
+                          <span
+                            class="mg-amount"
+                            data-monthly={tier.monthly}
+                            data-annual={Math.round((tier.annual ?? 0) / 12)}
+                          >
+                            €{tier.monthly}
+                          </span>
+                          <span class="mg-per">/ month</span>
+                        </Fragment>
+                      )}
+                    </div>
+                    {!tier.contact && (
+                      <div class="mg-price-note" data-annual-total={tier.annual}>
+                        billed monthly
+                      </div>
                     )}
                   </div>
-                  {!tier.contact && (
-                    <div class="mg-price-note" data-annual-total={tier.annual}>
-                      billed monthly
-                    </div>
-                  )}
+                  <div class="mg-goodfor">{tier.goodFor}</div>
                 </div>
                 <ul class="mg-price-feats">
                   {tier.inherits && (
@@ -1153,6 +1155,10 @@ const faqSchema = JSON.stringify({
     .mg-pricing-grid {
       grid-template-columns: 1fr;
     }
+    .mg-goodfor,
+    .mg-price-block {
+      min-height: 0;
+    }
   }
 
   /* ── Pricing: billing toggle ──────────────────────────────── */
@@ -1229,18 +1235,24 @@ const faqSchema = JSON.stringify({
     background: var(--accent);
     color: #fff;
   }
+  .mg-price-head {
+    display: block;
+  }
+  .mg-price-block {
+    margin-top: 14px;
+    min-height: 62px;
+  }
   .mg-goodfor {
-    margin-top: 8px;
-    font-size: 12.5px;
+    margin-top: 14px;
+    min-height: 130px;
+    font-size: 13px;
     line-height: 1.5;
     color: var(--ink-3);
-    min-height: 4.5em;
   }
   .mg-price {
     display: flex;
     align-items: baseline;
     gap: 6px;
-    margin-top: 16px;
   }
   .mg-amount,
   .mg-price-contact {

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -173,6 +173,41 @@ const pricingTiers = [
   },
 ];
 
+const pricingFaqs = [
+  {
+    q: "What's included in a managed plan?",
+    a: "Every managed tier covers hosting, deployment, monitoring, and the updates listed for that tier. Higher tiers add dashboards, audit logs, rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
+  },
+  {
+    q: "What counts as a device?",
+    a: "A device is any client that connects to the platform and exchanges messages, regardless of protocol (MQTT, CoAP, HTTP, or WebSocket). The device and message figures on each tier are guidance for typical workloads, not hard quotas.",
+  },
+  {
+    q: "What happens if I exceed my device or message limit?",
+    a: "Limits are soft. We monitor usage and reach out to move you to the tier that fits, rather than cutting you off mid-cycle. If a burst is temporary, nothing breaks.",
+  },
+  {
+    q: "Can I change plans later?",
+    a: "Yes. You can move up or down between tiers at any time. Changes are prorated, so you only pay for what you use in a billing period.",
+  },
+  {
+    q: "How does annual billing work?",
+    a: "Annual plans are billed once per year and work out roughly 10% cheaper than paying monthly. You can switch between monthly and annual billing when your term renews.",
+  },
+  {
+    q: "Can I deploy on my own cloud or on-premises?",
+    a: "Yes, through the Custom plan. We can deploy Magistrala into your AWS, GCP, or Azure account, or fully on-premises, including air-gapped environments, with data residency handled on your infrastructure.",
+  },
+  {
+    q: "Do you offer a custom SLA and high availability?",
+    a: "Enterprise, Dedicated, and Custom plans support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the tier; the Custom plan is tailored to your requirements.",
+  },
+  {
+    q: "Is self-hosting free?",
+    a: "Yes. Magistrala is open source under the Apache 2.0 license and free to self-host forever, with community support. The managed tiers exist for teams that would rather not run the infrastructure themselves.",
+  },
+];
+
 const faqs = [
   {
     q: "Can I self-host Magistrala?",
@@ -813,6 +848,30 @@ const faqSchema = JSON.stringify({
           }
         </div>
 
+        <div class="mg-custom">
+          <div class="mg-custom-main">
+            <div class="label">Custom</div>
+            <h3>Bring your own cloud, on your terms.</h3>
+            <p>
+              For large or regulated deployments, we run Magistrala wherever you
+              need it, tailored to your scale, compliance, and integration
+              requirements.
+            </p>
+            <ul class="mg-custom-feats">
+              <li>→ Deploy on your cloud (AWS, GCP, Azure) or on-premises</li>
+              <li>→ Custom SLA with defined uptime guarantees</li>
+              <li>→ High-availability clustering</li>
+              <li>→ Dedicated infrastructure &amp; data residency</li>
+              <li>→ Custom integrations &amp; message formats</li>
+              <li>→ Priority engineering support</li>
+            </ul>
+          </div>
+          <div class="mg-custom-aside">
+            <div class="mg-custom-price">Custom pricing</div>
+            <a href="/contact" class="btn mg-custom-btn">Contact sales →</a>
+          </div>
+        </div>
+
         <p
           style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
         >
@@ -824,6 +883,16 @@ const faqSchema = JSON.stringify({
             >Talk to us</a
           >.
         </p>
+
+        <div class="mg-price-faq">
+          <div class="mg-price-faq-head">
+            <span class="kicker">Pricing FAQ</span>
+            <h3 class="h-3" style="margin-top:12px;">
+              Questions about plans &amp; billing.
+            </h3>
+          </div>
+          <FAQAccordion items={pricingFaqs} />
+        </div>
       </div>
     </section>
 
@@ -1174,6 +1243,94 @@ const faqSchema = JSON.stringify({
   .mg-inherit {
     font-weight: 600;
     color: var(--ink);
+  }
+
+  /* ── Pricing: custom / dedicated banner ───────────────────── */
+  .mg-custom {
+    margin-top: 20px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
+    gap: 40px;
+    align-items: center;
+    padding: 40px;
+    border-radius: var(--radius-lg);
+    background: var(--surface-accent);
+    color: var(--on-accent);
+    border: 1px solid var(--surface-accent);
+  }
+  .mg-custom-main .label {
+    font-family: var(--font-mono), monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--accent-2);
+  }
+  .mg-custom-main h3 {
+    margin: 10px 0 0;
+    font-size: 26px;
+    font-weight: 600;
+    color: var(--on-accent);
+  }
+  .mg-custom-main > p {
+    margin: 12px 0 0;
+    max-width: 62ch;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--on-accent-dim);
+  }
+  .mg-custom-feats {
+    list-style: none;
+    padding: 0;
+    margin: 20px 0 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px 28px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--on-accent-dim);
+  }
+  .mg-custom-aside {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
+  .mg-custom-price {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--on-accent);
+  }
+  .mg-custom-btn {
+    background: var(--on-accent);
+    color: var(--ink);
+    border-color: var(--on-accent);
+  }
+  .mg-custom-btn:hover {
+    background: #fff;
+    border-color: #fff;
+  }
+  @media (max-width: 820px) {
+    .mg-custom {
+      grid-template-columns: 1fr;
+      gap: 28px;
+      padding: 32px 26px;
+    }
+    .mg-custom-feats {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* ── Pricing FAQ ──────────────────────────────────────────── */
+  .mg-price-faq {
+    max-width: 860px;
+    margin: 64px auto 0;
+  }
+  .mg-price-faq-head {
+    text-align: center;
+    margin-bottom: 32px;
+  }
+  .mg-price-faq-head .kicker {
+    display: block;
   }
 
   /* ── Magistrala hero diagram ───────────────────────────────── */

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -106,11 +106,14 @@ const integrations = [
 const pricingTiers = [
   {
     name: "Starter",
-    capacity: "~50 devices · 100k messages",
+    goodFor: "Small proofs of concept and testing.",
     monthly: 50,
     annual: 540,
+    transfer: "3 TB data transfer",
+    capacity: "~50 devices · 100k messages / month",
     inherits: null,
     featured: false,
+    contact: false,
     cta: "Get started",
     features: [
       "Commercial UI with whitelabeling",
@@ -120,55 +123,76 @@ const pricingTiers = [
     ],
   },
   {
-    name: "Growth",
-    capacity: "~250 devices · 1M messages",
-    monthly: 150,
-    annual: 1620,
+    name: "Prototype",
+    goodFor:
+      "Pilot projects and small deployments with low message bandwidth, where occasional message loss is acceptable.",
+    monthly: 200,
+    annual: 2160,
+    transfer: "5 TB data transfer",
+    capacity: "~250 devices · 1M messages / month",
     inherits: "Starter",
     featured: false,
+    contact: false,
     cta: "Get started",
     features: ["UI and backend updates", "Dashboards", "Audit logs"],
   },
   {
     name: "Business",
-    capacity: "~1k devices · 10M messages",
-    monthly: 350,
-    annual: 3780,
-    inherits: "Growth",
+    goodFor:
+      "Deployments where availability matters and flexibility and features are important. This is where your business starts.",
+    monthly: 500,
+    annual: 5400,
+    transfer: "8 TB data transfer",
+    capacity: "~10k devices · 100M messages / month",
+    inherits: "Prototype",
     featured: true,
+    contact: false,
     cta: "Get started",
     features: [
       "Rules Engine & custom message format",
-      "Priority support & issue addressing",
-    ],
-  },
-  {
-    name: "Enterprise",
-    capacity: "~10k devices · 100M messages",
-    monthly: 500,
-    annual: 5400,
-    inherits: "Business",
-    featured: false,
-    cta: "Get started",
-    features: [
       "Alarms",
       "Reports",
+      "Priority support & issue addressing",
       "Dedicated support 2h / month",
       "Weekly backup, 3-month retention",
     ],
   },
   {
-    name: "Dedicated",
-    capacity: "~100k devices · 1B messages",
-    monthly: 750,
-    annual: 8100,
-    inherits: "Enterprise",
+    name: "Enterprise",
+    goodFor: "Larger deployments where stability and performance matter.",
+    monthly: 1000,
+    annual: 10800,
+    transfer: "8 TB data transfer",
+    capacity: "~100k devices · 1B messages / month",
+    inherits: "Business",
     featured: false,
-    cta: "Contact sales",
+    contact: false,
+    cta: "Get started",
     features: [
       "Highest-priority support & issue addressing",
-      "Dedicated support 12h / month",
-      "Daily backup, 3-month retention",
+      "Dedicated support 12h / month (instead of 2)",
+      "Daily backup, 3-month retention (instead of weekly)",
+    ],
+  },
+  {
+    name: "Custom",
+    goodFor:
+      "Large production deployments where HA and SLA matter — huge device and message volumes, no acceptable message loss, and strict data residency and compliance.",
+    monthly: null,
+    annual: null,
+    transfer: null,
+    capacity: null,
+    inherits: null,
+    featured: false,
+    contact: true,
+    cta: "Contact sales",
+    features: [
+      "Deploy on our dedicated cloud, your cloud (AWS, GCP, Azure), or on-premises",
+      "Custom SLA with defined uptime guarantees",
+      "High-availability clustering",
+      "Dedicated infrastructure & data residency",
+      "Custom integrations & message formats",
+      "Priority engineering support",
     ],
   },
 ];
@@ -809,24 +833,34 @@ const faqSchema = JSON.stringify({
         <div class="mg-pricing-grid">
           {
             pricingTiers.map((tier) => (
-              <div class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}`}>
+              <div
+                class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}${tier.contact ? " is-custom" : ""}`}
+              >
                 {tier.featured && <span class="mg-badge">Popular</span>}
                 <div>
                   <div class="label">{tier.name}</div>
-                  <div class="mg-capacity">{tier.capacity}</div>
+                  <div class="mg-goodfor">{tier.goodFor}</div>
                   <div class="mg-price">
-                    <span
-                      class="mg-amount"
-                      data-monthly={tier.monthly}
-                      data-annual={Math.round(tier.annual / 12)}
-                    >
-                      €{tier.monthly}
-                    </span>
-                    <span class="mg-per">/ month</span>
+                    {tier.contact ? (
+                      <span class="mg-price-contact">Contact</span>
+                    ) : (
+                      <Fragment>
+                        <span
+                          class="mg-amount"
+                          data-monthly={tier.monthly}
+                          data-annual={Math.round((tier.annual ?? 0) / 12)}
+                        >
+                          €{tier.monthly}
+                        </span>
+                        <span class="mg-per">/ month</span>
+                      </Fragment>
+                    )}
                   </div>
-                  <div class="mg-price-note" data-annual-total={tier.annual}>
-                    billed monthly
-                  </div>
+                  {!tier.contact && (
+                    <div class="mg-price-note" data-annual-total={tier.annual}>
+                      billed monthly
+                    </div>
+                  )}
                 </div>
                 <ul class="mg-price-feats">
                   {tier.inherits && (
@@ -835,6 +869,10 @@ const faqSchema = JSON.stringify({
                   {tier.features.map((feature) => (
                     <li>→ {feature}</li>
                   ))}
+                  {tier.capacity && (
+                    <li class="mg-cap-feat">→ {tier.capacity}</li>
+                  )}
+                  {tier.transfer && <li>→ {tier.transfer}</li>}
                 </ul>
                 <a
                   href="/contact"
@@ -846,30 +884,6 @@ const faqSchema = JSON.stringify({
               </div>
             ))
           }
-        </div>
-
-        <div class="mg-custom">
-          <div class="mg-custom-main">
-            <div class="label">Custom</div>
-            <h3>Bring your own cloud, on your terms.</h3>
-            <p>
-              For large or regulated deployments, we run Magistrala wherever you
-              need it, tailored to your scale, compliance, and integration
-              requirements.
-            </p>
-            <ul class="mg-custom-feats">
-              <li>→ Deploy on your cloud (AWS, GCP, Azure) or on-premises</li>
-              <li>→ Custom SLA with defined uptime guarantees</li>
-              <li>→ High-availability clustering</li>
-              <li>→ Dedicated infrastructure &amp; data residency</li>
-              <li>→ Custom integrations &amp; message formats</li>
-              <li>→ Priority engineering support</li>
-            </ul>
-          </div>
-          <div class="mg-custom-aside">
-            <div class="mg-custom-price">Custom pricing</div>
-            <a href="/contact" class="btn mg-custom-btn">Contact sales →</a>
-          </div>
         </div>
 
         <p
@@ -1201,10 +1215,12 @@ const faqSchema = JSON.stringify({
     background: var(--accent);
     color: #fff;
   }
-  .mg-capacity {
-    margin-top: 6px;
-    font-size: 13px;
-    color: var(--ink-2);
+  .mg-goodfor {
+    margin-top: 8px;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--ink-3);
+    min-height: 4.5em;
   }
   .mg-price {
     display: flex;
@@ -1212,11 +1228,15 @@ const faqSchema = JSON.stringify({
     gap: 6px;
     margin-top: 16px;
   }
-  .mg-amount {
+  .mg-amount,
+  .mg-price-contact {
     font-size: 34px;
     font-weight: 700;
     color: var(--ink);
     line-height: 1;
+  }
+  .mg-price-contact {
+    font-size: 28px;
   }
   .mg-per {
     font-size: 13px;
@@ -1244,80 +1264,12 @@ const faqSchema = JSON.stringify({
     font-weight: 600;
     color: var(--ink);
   }
-
-  /* ── Pricing: custom / dedicated banner ───────────────────── */
-  .mg-custom {
-    margin-top: 20px;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
-    gap: 40px;
-    align-items: center;
-    padding: 40px;
-    border-radius: var(--radius-lg);
-    background: var(--surface-accent);
-    color: var(--on-accent);
-    border: 1px solid var(--surface-accent);
-  }
-  .mg-custom-main .label {
-    font-family: var(--font-mono), monospace;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--accent-2);
-  }
-  .mg-custom-main h3 {
-    margin: 10px 0 0;
-    font-size: 26px;
+  .mg-cap-feat {
     font-weight: 600;
-    color: var(--on-accent);
-  }
-  .mg-custom-main > p {
-    margin: 12px 0 0;
-    max-width: 62ch;
-    font-size: 15px;
-    line-height: 1.6;
-    color: var(--on-accent-dim);
-  }
-  .mg-custom-feats {
-    list-style: none;
-    padding: 0;
-    margin: 20px 0 0;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px 28px;
-    font-size: 14px;
-    line-height: 1.5;
-    color: var(--on-accent-dim);
-  }
-  .mg-custom-aside {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 14px;
-  }
-  .mg-custom-price {
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--on-accent);
-  }
-  .mg-custom-btn {
-    background: var(--on-accent);
     color: var(--ink);
-    border-color: var(--on-accent);
   }
-  .mg-custom-btn:hover {
-    background: #fff;
-    border-color: #fff;
-  }
-  @media (max-width: 820px) {
-    .mg-custom {
-      grid-template-columns: 1fr;
-      gap: 28px;
-      padding: 32px 26px;
-    }
-    .mg-custom-feats {
-      grid-template-columns: 1fr;
-    }
+  .mg-price-card.is-custom {
+    background: var(--paper-2);
   }
 
   /* ── Pricing FAQ ──────────────────────────────────────────── */

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -120,7 +120,7 @@ const faqs = [
   },
   {
     q: "Is there a free option, and what does the managed cloud cost?",
-    a: "The open-source core and Community Edition are free to self-host forever, and you can start for free on the shared cloud to evaluate the platform. For production, managed plans run on dedicated instances — starting at €50/month for Starter, up to Enterprise, plus a Custom plan for large or regulated deployments. Each plan lists the devices, messages, and data transfer it comfortably handles.",
+    a: "The open-source core and Community Edition are free to self-host forever, and you can start for free on the shared cloud to evaluate the platform. For production, managed Private Cloud plans run on dedicated instances — starting at €150/month, up to Enterprise, plus a Custom plan for large or regulated deployments. You can also self-manage Magistrala Enterprise Edition under your own license.",
     link: { href: "/pricing", label: "See all plans" },
   },
   {

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -103,6 +103,76 @@ const integrations = [
   { name: "JWT" },
 ];
 
+const pricingTiers = [
+  {
+    name: "Starter",
+    capacity: "~50 devices · 100k messages",
+    monthly: 50,
+    annual: 540,
+    inherits: null,
+    featured: false,
+    cta: "Get started",
+    features: [
+      "Commercial UI with whitelabeling",
+      "Basic UI patches",
+      "Security fixes",
+      "Community support",
+    ],
+  },
+  {
+    name: "Growth",
+    capacity: "~250 devices · 1M messages",
+    monthly: 150,
+    annual: 1620,
+    inherits: "Starter",
+    featured: false,
+    cta: "Get started",
+    features: ["UI and backend updates", "Dashboards", "Audit logs"],
+  },
+  {
+    name: "Business",
+    capacity: "~1k devices · 10M messages",
+    monthly: 350,
+    annual: 3780,
+    inherits: "Growth",
+    featured: true,
+    cta: "Get started",
+    features: [
+      "Rules Engine & custom message format",
+      "Priority support & issue addressing",
+    ],
+  },
+  {
+    name: "Enterprise",
+    capacity: "~10k devices · 100M messages",
+    monthly: 500,
+    annual: 5400,
+    inherits: "Business",
+    featured: false,
+    cta: "Get started",
+    features: [
+      "Alarms",
+      "Reports",
+      "Dedicated support 2h / month",
+      "Weekly backup, 3-month retention",
+    ],
+  },
+  {
+    name: "Dedicated",
+    capacity: "~100k devices · 1B messages",
+    monthly: 750,
+    annual: 8100,
+    inherits: "Enterprise",
+    featured: false,
+    cta: "Contact sales",
+    features: [
+      "Highest-priority support & issue addressing",
+      "Dedicated support 12h / month",
+      "Daily backup, 3-month retention",
+    ],
+  },
+];
+
 const faqs = [
   {
     q: "Can I self-host Magistrala?",
@@ -679,87 +749,119 @@ const faqSchema = JSON.stringify({
           <div class="left">
             <span class="kicker">Pricing</span>
             <h2 class="h-2" style="margin-top:14px;">
-              Start free. Scale when you're ready.
+              Managed Magistrala, priced to scale.
             </h2>
           </div>
           <p class="lede">
-            Self-host for free forever, or use the managed cloud with a free
-            tier and enterprise options.
+            Fully managed deployments with hosting, updates, and support. Pick
+            the tier that matches your fleet and move up as you grow.
           </p>
         </div>
-        <div class="mg-pricing-grid">
-          <div
-            class="cta-card"
-            style="padding:40px; gap:20px; display:flex; flex-direction:column;"
-          >
-            <div>
-              <div class="label">Free tier</div>
-              <h3 style="margin-top:8px;">Community</h3>
-              <p
-                style="font-size:36px; font-weight:700; margin:12px 0 0; color:var(--ink);"
-              >
-                $0<span
-                  style="font-size:15px; font-weight:400; color:var(--ink-3);"
-                >
-                  / month</span
-                >
-              </p>
-            </div>
-            <ul
-              style="list-style:none; padding:0; margin:0; flex:1; display:flex; flex-direction:column; gap:9px; font-size:14px; color:var(--ink-2);"
+
+        <div class="mg-price-wrap">
+          <div class="mg-price-toggle" role="group" aria-label="Billing period">
+            <button
+              type="button"
+              class="mg-price-opt is-active"
+              data-billing="monthly">Monthly</button
             >
-              <li>→ 10 users</li>
-              <li>→ 10 clients</li>
-              <li>→ 10 channels</li>
-              <li>→ 10 groups</li>
-              <li>→ 10,000 messages / month</li>
-              <li>→ Community support</li>
-            </ul>
-            <a
-              href="https://cloud.magistrala.absmach.eu"
-              class="btn"
-              target="_blank"
-              rel="noopener"
-              style="margin-top:auto; text-align:center; justify-content:center;"
-              >Start Free ↗</a
-            >
-          </div>
-          <div
-            class="cta-card dark"
-            style="padding:40px; gap:20px; display:flex; flex-direction:column;"
-          >
-            <div>
-              <div class="label">Enterprise</div>
-              <h3 style="margin-top:8px; color:var(--paper);">Enterprise</h3>
-              <p
-                style="font-size:20px; font-weight:600; margin:12px 0 0; color:rgba(246,244,238,0.75);"
-              >
-                Custom pricing
-              </p>
-            </div>
-            <ul
-              style="list-style:none; padding:0; margin:0; flex:1; display:flex; flex-direction:column; gap:9px; font-size:14px; color:rgba(246,244,238,0.8);"
-            >
-              <li>→ Multitenant support</li>
-              <li>→ Unlimited users</li>
-              <li>→ Custom dashboards</li>
-              <li>→ Unlimited clients</li>
-              <li>→ Unlimited channels</li>
-              <li>→ Unlimited groups</li>
-              <li>→ Unlimited messages</li>
-              <li>→ Premium SLA support</li>
-              <li>→ Dedicated infrastructure</li>
-            </ul>
-            <a
-              href="/contact"
-              class="btn"
-              style="margin-top:auto; text-align:center; justify-content:center; background:rgba(246,244,238,0.1); border-color:rgba(246,244,238,0.25); color:var(--paper);"
-              >Contact Sales</a
+            <button type="button" class="mg-price-opt" data-billing="annual"
+              >Annual <span class="mg-save">Save 10%</span></button
             >
           </div>
         </div>
+
+        <div class="mg-pricing-grid">
+          {
+            pricingTiers.map((tier) => (
+              <div class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}`}>
+                {tier.featured && <span class="mg-badge">Popular</span>}
+                <div>
+                  <div class="label">{tier.name}</div>
+                  <div class="mg-capacity">{tier.capacity}</div>
+                  <div class="mg-price">
+                    <span
+                      class="mg-amount"
+                      data-monthly={tier.monthly}
+                      data-annual={Math.round(tier.annual / 12)}
+                    >
+                      €{tier.monthly}
+                    </span>
+                    <span class="mg-per">/ month</span>
+                  </div>
+                  <div class="mg-price-note" data-annual-total={tier.annual}>
+                    billed monthly
+                  </div>
+                </div>
+                <ul class="mg-price-feats">
+                  {tier.inherits && (
+                    <li class="mg-inherit">Everything in {tier.inherits}, plus:</li>
+                  )}
+                  {tier.features.map((feature) => (
+                    <li>→ {feature}</li>
+                  ))}
+                </ul>
+                <a
+                  href="/contact"
+                  class={`btn${tier.featured ? " btn-primary" : ""}`}
+                  style="margin-top:auto; text-align:center; justify-content:center;"
+                >
+                  {tier.cta} →
+                </a>
+              </div>
+            ))
+          }
+        </div>
+
+        <p
+          style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
+        >
+          Prefer to run it yourself? The <a
+            href="/open-source"
+            style="color:inherit; text-decoration:underline;">open-source platform</a
+          > is free forever. Need more than 100k devices?{" "}
+          <a href="/contact" style="color:inherit; text-decoration:underline;"
+            >Talk to us</a
+          >.
+        </p>
       </div>
     </section>
+
+    <script>
+      const toggle = document.querySelector(".mg-price-toggle");
+      if (toggle) {
+        const opts =
+          toggle.querySelectorAll<HTMLButtonElement>(".mg-price-opt");
+        const amounts =
+          document.querySelectorAll<HTMLElement>(".mg-amount");
+        const notes =
+          document.querySelectorAll<HTMLElement>(".mg-price-note");
+
+        const setBilling = (mode: string) => {
+          opts.forEach((o) =>
+            o.classList.toggle("is-active", o.dataset.billing === mode),
+          );
+          amounts.forEach((a) => {
+            const value =
+              mode === "annual" ? a.dataset.annual : a.dataset.monthly;
+            a.textContent = `€${value}`;
+          });
+          notes.forEach((n) => {
+            const total = Number(n.dataset.annualTotal);
+            n.textContent =
+              mode === "annual"
+                ? `€${total.toLocaleString()} billed yearly`
+                : "billed monthly";
+          });
+        };
+
+        opts.forEach((o) =>
+          o.addEventListener("click", () =>
+            setBilling(o.dataset.billing ?? "monthly"),
+          ),
+        );
+      }
+    </script>
 
     <!-- FAQ -->
     <section
@@ -920,16 +1022,23 @@ const faqSchema = JSON.stringify({
   }
   .mg-pricing-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(5, 1fr);
     gap: 16px;
-    max-width: 880px;
+    align-items: stretch;
+  }
+  @media (max-width: 1200px) {
+    .mg-pricing-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+  @media (max-width: 820px) {
+    .mg-pricing-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
   @media (max-width: 980px) {
     .mg-depl-grid {
       grid-template-columns: 1fr;
-    }
-    .mg-pricing-grid {
-      max-width: 100%;
     }
   }
   @media (max-width: 640px) {
@@ -942,9 +1051,129 @@ const faqSchema = JSON.stringify({
     .mg-feat-grid {
       grid-template-columns: 1fr;
     }
+  }
+  @media (max-width: 560px) {
     .mg-pricing-grid {
       grid-template-columns: 1fr;
     }
+  }
+
+  /* ── Pricing: billing toggle ──────────────────────────────── */
+  .mg-price-wrap {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 44px;
+  }
+  .mg-price-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    border: 1px solid var(--line-3);
+    border-radius: 999px;
+    background: var(--paper);
+  }
+  .mg-price-opt {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 18px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--ink-3);
+    font: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+  }
+  .mg-price-opt.is-active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+  .mg-save {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+  .mg-price-opt.is-active .mg-save {
+    background: rgba(246, 244, 238, 0.2);
+    color: var(--paper);
+  }
+
+  /* ── Pricing: tier cards ──────────────────────────────────── */
+  .mg-price-card {
+    position: relative;
+    padding: 32px 26px;
+    gap: 16px;
+    min-height: 0;
+  }
+  .mg-price-card.is-featured {
+    border-color: var(--ink);
+    box-shadow: var(--shadow-lg);
+  }
+  .mg-badge {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    font-family: var(--font-mono), monospace;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: #fff;
+  }
+  .mg-capacity {
+    margin-top: 6px;
+    font-size: 13px;
+    color: var(--ink-2);
+  }
+  .mg-price {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    margin-top: 16px;
+  }
+  .mg-amount {
+    font-size: 34px;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1;
+  }
+  .mg-per {
+    font-size: 13px;
+    color: var(--ink-3);
+  }
+  .mg-price-note {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--ink-3);
+    min-height: 16px;
+  }
+  .mg-price-feats {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+  .mg-inherit {
+    font-weight: 600;
+    color: var(--ink);
   }
 
   /* ── Magistrala hero diagram ───────────────────────────────── */

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -4,6 +4,7 @@ import Header from "../../components/Header.astro";
 import AnnouncementBanner from "../../components/AnnouncementBanner.astro";
 import Footer from "../../components/Footer.astro";
 import FAQAccordion from "../../components/FAQAccordion.astro";
+import Pricing from "../../components/Pricing.astro";
 import { deployments } from "../../data/deployments";
 import { solutions } from "../../data/solutions";
 import { Network, ShieldCheck, ChartBar, KeyRound } from "@lucide/astro";
@@ -103,153 +104,11 @@ const integrations = [
   { name: "JWT" },
 ];
 
-const pricingTiers = [
-  {
-    name: "Starter",
-    goodFor: "Small proofs of concept and testing.",
-    monthly: 50,
-    annual: 540,
-    transfer: "3 TB data transfer",
-    capacity: "~50 devices · 100k messages / month",
-    inherits: null,
-    featured: false,
-    contact: false,
-    cta: "Get started",
-    features: [
-      "Commercial UI with whitelabeling",
-      "Basic UI patches",
-      "Security fixes",
-      "Community support",
-    ],
-  },
-  {
-    name: "Prototype",
-    goodFor:
-      "Pilot projects and small deployments with low message bandwidth, where occasional message loss is acceptable.",
-    monthly: 200,
-    annual: 2160,
-    transfer: "5 TB data transfer",
-    capacity: "~250 devices · 1M messages / month",
-    inherits: "Starter",
-    featured: false,
-    contact: false,
-    cta: "Get started",
-    features: ["UI and backend updates", "Dashboards", "Audit logs"],
-  },
-  {
-    name: "Business",
-    goodFor:
-      "Deployments where availability matters and flexibility and features are important. This is where your business starts.",
-    monthly: 500,
-    annual: 5400,
-    transfer: "8 TB data transfer",
-    capacity: "~10k devices · 100M messages / month",
-    inherits: "Prototype",
-    featured: true,
-    contact: false,
-    cta: "Get started",
-    features: [
-      "Rules Engine & custom message format",
-      "Alarms",
-      "Reports",
-      "Priority support & issue addressing",
-      "Dedicated support 2h / month",
-      "Weekly backup, 3-month retention",
-    ],
-  },
-  {
-    name: "Enterprise",
-    goodFor: "Larger deployments where stability and performance matter.",
-    monthly: 1000,
-    annual: 10800,
-    transfer: "8 TB data transfer",
-    capacity: "~100k devices · 1B messages / month",
-    inherits: "Business",
-    featured: false,
-    contact: false,
-    cta: "Get started",
-    features: [
-      "Highest-priority support & issue addressing",
-      "Dedicated support 12h / month (instead of 2)",
-      "Daily backup, 3-month retention (instead of weekly)",
-    ],
-  },
-  {
-    name: "Custom",
-    goodFor:
-      "Large production deployments where HA and SLA matter — huge device and message volumes, no acceptable message loss, and strict data residency and compliance.",
-    monthly: null,
-    annual: null,
-    transfer: null,
-    capacity: null,
-    inherits: null,
-    featured: false,
-    contact: true,
-    cta: "Contact sales",
-    features: [
-      "Deploy on our dedicated cloud, your cloud (AWS, GCP, Azure), or on-premises",
-      "Custom SLA with defined uptime guarantees",
-      "High-availability clustering",
-      "Dedicated infrastructure & data residency",
-      "Custom integrations & message formats",
-      "Priority engineering support",
-    ],
-  },
-];
-
-const pricingFaqs = [
-  {
-    q: "What's included in a managed plan?",
-    a: "Every managed tier covers hosting, deployment, monitoring, and the updates listed for that tier. Higher tiers add dashboards, audit logs, rules engine, alarms, reports, and scheduled backups. You focus on your devices and data; we run the platform.",
-  },
-  {
-    q: "What counts as a device?",
-    a: "A device is any client that connects to the platform and exchanges messages, regardless of protocol (MQTT, CoAP, HTTP, or WebSocket). The device and message figures on each tier are guidance for typical workloads, not hard quotas.",
-  },
-  {
-    q: "Do I get a dedicated instance?",
-    a: "Yes. Every plan runs on a dedicated instance — no shared infrastructure. We provision, run, and manage the instance for you.",
-  },
-  {
-    q: "What does “~250 devices · 1M messages / month” actually mean?",
-    a: "Because each tier is a dedicated instance, that figure is a rough estimate of how many concurrent devices and messages the instance can comfortably handle. It is not a hard cap — we don't limit you artificially; the only real limit is the hardware and how it's set up. We deliberately avoid a messages-per-second metric, because it's a weak and misleading number for a few reasons:",
-    points: [
-      "Message size varies enormously. A ping is a message, and so is a 100 MB binary upload — they don't cost the same, and they aren't the same priority.",
-      "Networking hiccups and load balancing have an outsized impact as you approach the upper limit of throughput.",
-      "Messages carry different delivery modes and quality-of-service guarantees — not all messages are equally important.",
-      "Throughput also depends on delivery semantics: whether it includes consumer delivery and message persistence. Slow consumers can effectively serialize your infrastructure — and sometimes that's the intended behaviour, especially in low-bandwidth, high-QoS environments.",
-    ],
-  },
-  {
-    q: "What happens if I exceed my device or message limit?",
-    a: "Limits are soft. We monitor usage and reach out to move you to the tier that fits, rather than cutting you off mid-cycle. If a burst is temporary, nothing breaks.",
-  },
-  {
-    q: "Can I change plans later?",
-    a: "Yes. You can move up or down between tiers at any time. Changes are prorated, so you only pay for what you use in a billing period.",
-  },
-  {
-    q: "How does annual billing work?",
-    a: "Annual plans are billed once per year and work out roughly 10% cheaper than paying monthly. You can switch between monthly and annual billing when your term renews.",
-  },
-  {
-    q: "Can I deploy on my own cloud or on-premises?",
-    a: "Yes, through the Custom plan. We can deploy Magistrala into your AWS, GCP, or Azure account, or fully on-premises, including air-gapped environments, with data residency handled on your infrastructure.",
-  },
-  {
-    q: "Do you offer a custom SLA and high availability?",
-    a: "Custom plans support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the tier; the Custom plan is tailored to your requirements.",
-  },
-  {
-    q: "Is self-hosting free?",
-    a: "Partly. Magistrala core is open source under the Apache 2.0 license and free to self-host forever, as is the Magistrala Community Edition. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — is not free to self-host. See the self-hosting options for what each edition includes.",
-  },
-];
-
 const faqs = [
   {
     q: "Can I self-host Magistrala?",
-    a: "Yes. Magistrala is fully open source under the Apache 2.0 license. You can run it on your own infrastructure, a private cloud, or on-premises. Docker Compose and Kubernetes manifests are provided in the repository.",
+    a: "Yes. Magistrala core is open source under the Apache 2.0 license, and both the core and the Community Edition are free to self-host on your own infrastructure, a private cloud, or on-premises (Docker Compose and Kubernetes manifests included). The Enterprise Edition — which adds the rules engine, alarms, reports, audit logs, and dashboards — is a commercial edition. If you would rather not run it yourself, we offer fully managed plans.",
+    link: { href: "/pricing", label: "View managed pricing" },
   },
   {
     q: "What protocols does Magistrala support?",
@@ -260,8 +119,9 @@ const faqs = [
     a: "Yes. The Magistrala Agent runs on edge devices and acts as a bridge to the cloud platform over MQTT. It also manages Node-RED flows, executes remote commands, and handles heartbeat monitoring, giving you full control of the device from the cloud.",
   },
   {
-    q: "Is there a message limit on the free tier?",
-    a: "The free cloud tier includes 10,000 messages per month, with 10 users, 10 clients, 10 channels, and 10 groups. There are no limits on the open-source self-hosted version.",
+    q: "Is there a free option, and what does the managed cloud cost?",
+    a: "The open-source core and Community Edition are free to self-host forever, and you can start for free on the shared cloud to evaluate the platform. For production, managed plans run on dedicated instances — starting at €50/month for Starter, up to Enterprise, plus a Custom plan for large or regulated deployments. Each plan lists the devices, messages, and data transfer it comfortably handles.",
+    link: { href: "/pricing", label: "See all plans" },
   },
   {
     q: "How is Magistrala different from a plain MQTT broker?",
@@ -815,152 +675,7 @@ const faqSchema = JSON.stringify({
       </div>
     </section>
 
-    <!-- Pricing -->
-    <section class="section">
-      <div class="container-wide">
-        <div class="section-head">
-          <div class="left">
-            <span class="kicker">Pricing</span>
-            <h2 class="h-2" style="margin-top:14px;">
-              Managed Magistrala, priced to scale.
-            </h2>
-          </div>
-          <p class="lede">
-            Fully managed deployments with hosting, updates, and support. Pick
-            the tier that matches your fleet and move up as you grow.
-          </p>
-        </div>
-
-        <div class="mg-price-wrap">
-          <div class="mg-price-toggle" role="group" aria-label="Billing period">
-            <button
-              type="button"
-              class="mg-price-opt is-active"
-              data-billing="monthly">Monthly</button
-            >
-            <button type="button" class="mg-price-opt" data-billing="annual"
-              >Annual <span class="mg-save">Save 10%</span></button
-            >
-          </div>
-        </div>
-
-        <div class="mg-pricing-grid">
-          {
-            pricingTiers.map((tier) => (
-              <div
-                class={`cta-card mg-price-card${tier.featured ? " is-featured" : ""}${tier.contact ? " is-custom" : ""}`}
-              >
-                {tier.featured && <span class="mg-badge">Popular</span>}
-                <div class="mg-price-head">
-                  <div class="label">{tier.name}</div>
-                  <div class="mg-price-block">
-                    <div class="mg-price">
-                      {tier.contact ? (
-                        <span class="mg-price-contact">Contact</span>
-                      ) : (
-                        <Fragment>
-                          <span
-                            class="mg-amount"
-                            data-monthly={tier.monthly}
-                            data-annual={Math.round((tier.annual ?? 0) / 12)}
-                          >
-                            €{tier.monthly}
-                          </span>
-                          <span class="mg-per">/ month</span>
-                        </Fragment>
-                      )}
-                    </div>
-                    {!tier.contact && (
-                      <div class="mg-price-note" data-annual-total={tier.annual}>
-                        billed monthly
-                      </div>
-                    )}
-                  </div>
-                  <div class="mg-goodfor">{tier.goodFor}</div>
-                </div>
-                <ul class="mg-price-feats">
-                  {tier.inherits && (
-                    <li class="mg-inherit">Everything in {tier.inherits}, plus:</li>
-                  )}
-                  {tier.features.map((feature) => (
-                    <li>→ {feature}</li>
-                  ))}
-                  {tier.capacity && (
-                    <li class="mg-cap-feat">→ {tier.capacity}</li>
-                  )}
-                  {tier.transfer && <li>→ {tier.transfer}</li>}
-                </ul>
-                <a
-                  href="/contact"
-                  class={`btn${tier.featured ? " btn-primary" : ""}`}
-                  style="margin-top:auto; text-align:center; justify-content:center;"
-                >
-                  {tier.cta} →
-                </a>
-              </div>
-            ))
-          }
-        </div>
-
-        <p
-          style="margin-top:32px; text-align:center; font-size:14px; color:var(--ink-3);"
-        >
-          Prefer to run it yourself? The <a
-            href="/open-source"
-            style="color:inherit; text-decoration:underline;">open-source platform</a
-          > is free forever. Need more than 100k devices?{" "}
-          <a href="/contact" style="color:inherit; text-decoration:underline;"
-            >Talk to us</a
-          >.
-        </p>
-
-        <div class="mg-price-faq">
-          <div class="mg-price-faq-head">
-            <span class="kicker">Pricing FAQ</span>
-            <h3 class="h-3" style="margin-top:12px;">
-              Questions about plans &amp; billing.
-            </h3>
-          </div>
-          <FAQAccordion items={pricingFaqs} />
-        </div>
-      </div>
-    </section>
-
-    <script>
-      const toggle = document.querySelector(".mg-price-toggle");
-      if (toggle) {
-        const opts =
-          toggle.querySelectorAll<HTMLButtonElement>(".mg-price-opt");
-        const amounts =
-          document.querySelectorAll<HTMLElement>(".mg-amount");
-        const notes =
-          document.querySelectorAll<HTMLElement>(".mg-price-note");
-
-        const setBilling = (mode: string) => {
-          opts.forEach((o) =>
-            o.classList.toggle("is-active", o.dataset.billing === mode),
-          );
-          amounts.forEach((a) => {
-            const value =
-              mode === "annual" ? a.dataset.annual : a.dataset.monthly;
-            a.textContent = `€${value}`;
-          });
-          notes.forEach((n) => {
-            const total = Number(n.dataset.annualTotal);
-            n.textContent =
-              mode === "annual"
-                ? `€${total.toLocaleString()} billed yearly`
-                : "billed monthly";
-          });
-        };
-
-        opts.forEach((o) =>
-          o.addEventListener("click", () =>
-            setBilling(o.dataset.billing ?? "monthly"),
-          ),
-        );
-      }
-    </script>
+    <Pricing />
 
     <!-- FAQ -->
     <section
@@ -1119,22 +834,6 @@ const faqSchema = JSON.stringify({
     grid-template-columns: repeat(2, 1fr);
     gap: 16px;
   }
-  .mg-pricing-grid {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 16px;
-    align-items: stretch;
-  }
-  @media (max-width: 1200px) {
-    .mg-pricing-grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-  @media (max-width: 820px) {
-    .mg-pricing-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
   @media (max-width: 980px) {
     .mg-depl-grid {
       grid-template-columns: 1fr;
@@ -1150,165 +849,6 @@ const faqSchema = JSON.stringify({
     .mg-feat-grid {
       grid-template-columns: 1fr;
     }
-  }
-  @media (max-width: 560px) {
-    .mg-pricing-grid {
-      grid-template-columns: 1fr;
-    }
-    .mg-goodfor,
-    .mg-price-block {
-      min-height: 0;
-    }
-  }
-
-  /* ── Pricing: billing toggle ──────────────────────────────── */
-  .mg-price-wrap {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 44px;
-  }
-  .mg-price-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 4px;
-    border: 1px solid var(--line-3);
-    border-radius: 999px;
-    background: var(--paper);
-  }
-  .mg-price-opt {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 18px;
-    border: none;
-    border-radius: 999px;
-    background: transparent;
-    color: var(--ink-3);
-    font: inherit;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition:
-      background 0.15s ease,
-      color 0.15s ease;
-  }
-  .mg-price-opt.is-active {
-    background: var(--ink);
-    color: var(--paper);
-  }
-  .mg-save {
-    font-size: 11px;
-    font-weight: 600;
-    padding: 2px 7px;
-    border-radius: 999px;
-    background: var(--accent-soft);
-    color: var(--accent);
-  }
-  .mg-price-opt.is-active .mg-save {
-    background: rgba(246, 244, 238, 0.2);
-    color: var(--paper);
-  }
-
-  /* ── Pricing: tier cards ──────────────────────────────────── */
-  .mg-price-card {
-    position: relative;
-    padding: 32px 26px;
-    gap: 16px;
-    min-height: 0;
-  }
-  .mg-price-card.is-featured {
-    border-color: var(--ink);
-    box-shadow: var(--shadow-lg);
-  }
-  .mg-badge {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    font-family: var(--font-mono), monospace;
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    padding: 4px 9px;
-    border-radius: 999px;
-    background: var(--accent);
-    color: #fff;
-  }
-  .mg-price-head {
-    display: block;
-  }
-  .mg-price-block {
-    margin-top: 14px;
-    min-height: 62px;
-  }
-  .mg-goodfor {
-    margin-top: 14px;
-    min-height: 130px;
-    font-size: 13px;
-    line-height: 1.5;
-    color: var(--ink-3);
-  }
-  .mg-price {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-  }
-  .mg-amount,
-  .mg-price-contact {
-    font-size: 34px;
-    font-weight: 700;
-    color: var(--ink);
-    line-height: 1;
-  }
-  .mg-price-contact {
-    font-size: 28px;
-  }
-  .mg-per {
-    font-size: 13px;
-    color: var(--ink-3);
-  }
-  .mg-price-note {
-    margin-top: 6px;
-    font-size: 12px;
-    color: var(--ink-3);
-    min-height: 16px;
-  }
-  .mg-price-feats {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 9px;
-    font-size: 13.5px;
-    line-height: 1.5;
-    color: var(--ink-2);
-  }
-  .mg-inherit {
-    font-weight: 600;
-    color: var(--ink);
-  }
-  .mg-cap-feat {
-    font-weight: 600;
-    color: var(--ink);
-  }
-  .mg-price-card.is-custom {
-    background: var(--paper-2);
-  }
-
-  /* ── Pricing FAQ ──────────────────────────────────────────── */
-  .mg-price-faq {
-    max-width: 860px;
-    margin: 64px auto 0;
-  }
-  .mg-price-faq-head {
-    text-align: center;
-    margin-bottom: 32px;
-  }
-  .mg-price-faq-head .kicker {
-    display: block;
   }
 
   /* ── Magistrala hero diagram ───────────────────────────────── */

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -107,7 +107,7 @@ const integrations = [
 const faqs = [
   {
     q: "Can I self-host Magistrala?",
-    a: "Yes. Magistrala core is open source under the Apache 2.0 license, and both the core and the Community Edition are free to self-host on your own infrastructure, a private cloud, or on-premises (Docker Compose and Kubernetes manifests included). The Enterprise Edition — which adds the rules engine, alarms, reports, audit logs, and dashboards — is a commercial edition. If you would rather not run it yourself, we offer fully managed plans.",
+    a: "Yes. The Magistrala backend is open source under the Apache 2.0 license, and the Community Edition — the open-source backend plus a free-to-use UI you deploy as a Docker container — is free to self-host on your own infrastructure, a private cloud, or on-premises (Docker Compose and Kubernetes manifests included). The Enterprise Edition — which adds the rules engine, alarms, reports, audit logs, and dashboards — is a commercial edition. If you would rather not run it yourself, we offer fully managed plans.",
     link: { href: "/pricing", label: "View managed pricing" },
   },
   {

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -207,6 +207,20 @@ const pricingFaqs = [
     a: "A device is any client that connects to the platform and exchanges messages, regardless of protocol (MQTT, CoAP, HTTP, or WebSocket). The device and message figures on each tier are guidance for typical workloads, not hard quotas.",
   },
   {
+    q: "Do I get a dedicated instance?",
+    a: "Yes. Every plan runs on a dedicated instance — no shared infrastructure. We provision, run, and manage the instance for you.",
+  },
+  {
+    q: "What does “~250 devices · 1M messages / month” actually mean?",
+    a: "Because each tier is a dedicated instance, that figure is a rough estimate of how many concurrent devices and messages the instance can comfortably handle. It is not a hard cap — we don't limit you artificially; the only real limit is the hardware and how it's set up. We deliberately avoid a messages-per-second metric, because it's a weak and misleading number for a few reasons:",
+    points: [
+      "Message size varies enormously. A ping is a message, and so is a 100 MB binary upload — they don't cost the same, and they aren't the same priority.",
+      "Networking hiccups and load balancing have an outsized impact as you approach the upper limit of throughput.",
+      "Messages carry different delivery modes and quality-of-service guarantees — not all messages are equally important.",
+      "Throughput also depends on delivery semantics: whether it includes consumer delivery and message persistence. Slow consumers can effectively serialize your infrastructure — and sometimes that's the intended behaviour, especially in low-bandwidth, high-QoS environments.",
+    ],
+  },
+  {
     q: "What happens if I exceed my device or message limit?",
     a: "Limits are soft. We monitor usage and reach out to move you to the tier that fits, rather than cutting you off mid-cycle. If a burst is temporary, nothing breaks.",
   },
@@ -224,7 +238,7 @@ const pricingFaqs = [
   },
   {
     q: "Do you offer a custom SLA and high availability?",
-    a: "Enterprise, Dedicated, and Custom plans support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the tier; the Custom plan is tailored to your requirements.",
+    a: "Custom plans support defined uptime SLAs and high-availability clustering. Response-time commitments and dedicated support hours scale with the tier; the Custom plan is tailored to your requirements.",
   },
   {
     q: "Is self-hosting free?",

--- a/src/pages/products/magistrala.astro
+++ b/src/pages/products/magistrala.astro
@@ -242,7 +242,7 @@ const pricingFaqs = [
   },
   {
     q: "Is self-hosting free?",
-    a: "Yes. Magistrala is open source under the Apache 2.0 license and free to self-host forever, with community support. The managed tiers exist for teams that would rather not run the infrastructure themselves.",
+    a: "Partly. Magistrala core is open source under the Apache 2.0 license and free to self-host forever, as is the Magistrala Community Edition. The Enterprise Edition — which unlocks the full feature set, including the rules engine, alarms, reports, audit logs, and dashboards — is not free to self-host. See the self-hosting options for what each edition includes.",
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds a full pricing experience to the Abstract Machines site: a reusable, **tabbed** pricing block, a dedicated **/pricing** page, a matching header CTA, and an aligned pricing FAQ.

Pricing is split into three operating models (tabs): **Community**, **Private Cloud**, **Self-managed**.

## Tabs

**Community** — free, open-source Community Edition card ("Your free ticket to IoT"): unlimited devices/assets, unlimited updates, ability to contribute, community support. Install + Documentation links.

**Private Cloud** — fully managed, dedicated instances with a monthly/annual toggle (annual ~10% off):

| Tier | €/mo | €/yr | Transfer |
| --- | --- | --- | --- |
| Starter | 50 | 540 | 3 TB |
| Prototype | 200 | 2,160 | 5 TB |
| Business *(Popular)* | 500 | 5,400 | 8 TB |
| Enterprise | 1,000 | 10,800 | 8 TB |
| Custom | Contact | — | — |

**Self-managed** — Magistrala Enterprise Edition in your own environment, with a monthly/perpetual toggle:
- **License only** — €300 / cluster / month or €3,999 / cluster perpetual; full EE feature set.
- **Managed by us** — we deploy and operate EE on your infrastructure, aligned to your SLA, security, data-residency, and compliance requirements (contact).

## Details

- **`Pricing.astro` component** (single source of truth) — mounted on `/products/magistrala` and the new `/pricing` page (`showHead` prop suppresses its section header where the page supplies its own hero).
- **Tabs + panel-scoped toggles**: one generic, data-driven handler powers both the annual and perpetual toggles; monthly prices render server-side (progressive enhancement).
- **Header CTA** changed from "Contact us" to **Pricing** → `/pricing` (desktop + mobile). Contact remains in the footer and hero.
- **Pricing FAQ** updated for the three models (Community/Private/Self, per-cluster licensing, monthly vs perpetual, etc.).
- **Product-page FAQ refresh**: corrected self-hosting (Community free, Enterprise commercial), replaced the stale free-tier entry, and added `/pricing` links via a new optional `link` field on `FAQAccordion`.

## Testing

- `astro build` passes (`Complete!`, exit 0); `/pricing` and `/products/magistrala` generated, `/pricing` in the sitemap.
- Headless-Chrome renders verified all three tab panels (Community card, aligned Private Cloud 5-tier grid, Self-managed two-card layout) and the FAQ; no `€null`/`€undefined` leaks.