### PR TITLE
add Atom docs sitemap to index

### DIFF
--- a/src/pages/sitemap-index.xml.ts
+++ b/src/pages/sitemap-index.xml.ts
@@ -4,7 +4,7 @@ export const prerender = true;
 
 const DEFAULT_SITE = "https://www.absmach.eu";
 
-const DOCS_PRODUCTS = ["magistrala", "propeller", "hardware", "fluxmq"];
+const DOCS_PRODUCTS = ["magistrala", "propeller", "hardware", "fluxmq", "atom"];
 
 export const GET: APIRoute = ({ site }) => {
   const base = site ? site.href.replace(/\/$/, "") : DEFAULT_SITE;


### PR DESCRIPTION
Adds the Atom docs sitemap to the website sitemap index so crawlers can discover /docs/atom/sitemap.xml alongside the other docs products.\n\nVerification:\n- pnpm build\n- Confirmed dist/sitemap-index.xml includes https://www.absmach.eu/docs/atom/sitemap.xml\n\nNote:\n- pnpm lint currently fails on existing .wolf/hooks no-undef/no-empty issues unrelated to this change.